### PR TITLE
Removed Probabilty of Winners UI

### DIFF
--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -53,14 +53,7 @@
       <% extra_columns.each do |column| %>
         <th><%= column %></th>
       <% end %>
-      <th>
-        <form>
-          <select id="dropdown-<%=experiment.jstring(goal)%>" name="dropdown-<%=experiment.jstring(goal)%>">
-            <option value="confidence-<%=experiment.jstring(goal)%>">Confidence</option>
-            <option value="probability-<%=experiment.jstring(goal)%>">Probability of being Winner</option>
-          </select>
-        </form>
-      </th>
+      <th>Confidence</th>
       <th>Finish</th>
     </tr>
 
@@ -94,15 +87,6 @@
             <% end  %>
           <% end %>
         </td>
-        <script type="text/javascript" id="sourcecode">
-          $(document).ready(function(){
-            $('.probability-<%=experiment.jstring(goal)%>').hide();
-            $('#dropdown-<%=experiment.jstring(goal)%>').change(function() {
-              $('.box-<%=experiment.jstring(goal)%>').hide();
-              $('.' + $(this).val()).show();
-            });
-          });
-        </script>
         <% extra_columns.each do |column| %>
           <td><%= alternative.extra_info && alternative.extra_info[column] %></td>
         <% end %>
@@ -110,9 +94,6 @@
           <div class="box-<%=experiment.jstring(goal)%> confidence-<%=experiment.jstring(goal)%>">
             <span title='z-score: <%= round(alternative.z_score(goal), 3) %>'><%= confidence_level(alternative.z_score(goal)) %></span>
             <br>
-          </div>
-          <div class="box-<%=experiment.jstring(goal)%> probability-<%=experiment.jstring(goal)%>">
-            <span title="p_winner: <%= round(alternative.p_winner(goal), 3) %>"><%= number_to_percentage(round(alternative.p_winner(goal), 3)) %>%</span>
           </div>
         </td>
         <td>


### PR DESCRIPTION
### What does this do?
Removes "Probability of Winners" option from dropdown and related elements.

### Why is it important?
So dashboard users don't think they can use the Probability of Winners functionality.

### BEFORE

<img src="https://user-images.githubusercontent.com/1915331/76889868-96c7de80-6843-11ea-9e2a-f315fc09b3cd.png" width="150px" />

<img src="https://user-images.githubusercontent.com/1915331/76889885-9c252900-6843-11ea-8b18-0b6921fd5776.png" width="150px" />

### AFTER

<img src="https://user-images.githubusercontent.com/1915331/76889808-83b50e80-6843-11ea-88ef-c0b8bcbac580.png" width="150px" />
