### PR TITLE
Ensure Rails html escape is called within Rails

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -2,7 +2,13 @@
 module Split
   module DashboardHelpers
     def h(text)
-      Rack::Utils.escape_html(text)
+      #split-dashboard-port
+      # This exists because Rails and Sinatra return hex and decimal respectively, which can fail tests
+      if Object.const_defined?('Rails')
+        ERB::Util.html_escape(text)
+      else
+        Rack::Utils.escape_html(text)
+      end
     end
 
     def url(*path_parts)


### PR DESCRIPTION
### What does this do?
Ensures the Rails HTML escaping is called within Manage (and `h` does not use Sinatra HTML escaping instead).

### Why is this important?
So tests don't break in Manage. Sinatra and Rails will return decimal and hex encodings (one uses decimal, the other uses hex) which leads to failed specs. e.g. `' | &#39; | &#x27;`




https://buildkite.com/clio/clio-app-tests/builds/164847#24fe7e05-7701-42ef-a21f-de1a86056fa7/84-104