### PR TITLE
Revert "Ensure Rails html escape is called within Rails (#3)"

### DIFF
--- a/lib/split/dashboard/helpers.rb
+++ b/lib/split/dashboard/helpers.rb
@@ -2,13 +2,7 @@
 module Split
   module DashboardHelpers
     def h(text)
-      #split-dashboard-port
-      # This exists because Rails and Sinatra return hex and decimal respectively, which can fail tests
-      if Object.const_defined?('Rails')
-        ERB::Util.html_escape(text)
-      else
-        Rack::Utils.escape_html(text)
-      end
+      Rack::Utils.escape_html(text)
     end
 
     def url(*path_parts)


### PR DESCRIPTION
This reverts commit 4ccf6de6a89eaeef885d338601f8b669a6070c86.

We don't need to do this anymore because we can scope our helpers with `helper` syntax from the controller.