### PR TITLE
Added friendly_name helper to Experiment model

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -161,7 +161,8 @@ module Split
           goals: value_for(settings, :goals),
           metadata: value_for(settings, :metadata),
           algorithm: value_for(settings, :algorithm),
-          resettable: value_for(settings, :resettable)
+          resettable: value_for(settings, :resettable),
+          friendly_name: value_for(settings, :friendly_name)
         }
 
         experiment_data.each do |name, value|

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -27,7 +27,7 @@
 <div class="<%= experiment_class %>" data-name="<%= experiment.name %>" data-complete="<%= experiment.has_winner? %>">
   <div class="experiment-header">
     <h2>
-      Experiment: <%= experiment.name %>
+      Experiment: <%= experiment.friendly_name %>
       <% if experiment.version > 1 %><span class='version'>v<%= experiment.version %></span><% end %>
       <% unless goal.nil? %><span class='goal'>Goal:<%= goal %></span><% end %>
       <% metrics = @metrics.select {|metric| metric.experiments.include? experiment} %>

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -27,8 +27,7 @@ module Split
           goals: Split::GoalsCollection.new(@name).load_from_configuration,
           metadata: load_metadata_from_configuration,
           resettable: exp_config[:resettable],
-          algorithm: exp_config[:algorithm],
-          friendly_name: exp_config[:friendly_name]
+          algorithm: exp_config[:algorithm]
         }
       else
         options[:alternatives] = alternatives

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -299,6 +299,10 @@ module Split
       redis.hset(experiment_config_key, :cohorting, false)
     end
 
+    def friendly_name
+      metadata["friendly_name"]
+    end
+
     protected
 
     def experiment_config_key

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -376,7 +376,7 @@ module Split
       redis_interface.persist_list(name, @alternatives.map{|alt| {alt.name => alt.weight}.to_json})
       goals_collection.save
       redis.set(metadata_key, @metadata.to_json) unless @metadata.nil?
-      redis.set("#{@name}:friendly_name", self.friendly_name)
+      redis.set(friendly_name_key, self.friendly_name)
     end
 
     def remove_experiment_configuration

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -5,6 +5,7 @@ module Split
     attr_accessor :goals
     attr_accessor :alternative_probabilities
     attr_accessor :metadata
+    attr_accessor :friendly_name
 
     attr_reader :alternatives
     attr_reader :resettable
@@ -26,7 +27,8 @@ module Split
           goals: Split::GoalsCollection.new(@name).load_from_configuration,
           metadata: load_metadata_from_configuration,
           resettable: exp_config[:resettable],
-          algorithm: exp_config[:algorithm]
+          algorithm: exp_config[:algorithm],
+          friendly_name: exp_config[:friendly_name]
         }
       else
         options[:alternatives] = alternatives
@@ -49,6 +51,7 @@ module Split
       self.resettable = options_with_defaults[:resettable]
       self.algorithm = options_with_defaults[:algorithm]
       self.metadata = options_with_defaults[:metadata]
+      self.friendly_name = options_with_defaults[:friendly_name] || @name
     end
 
     def extract_alternatives_from_options(options)
@@ -68,6 +71,7 @@ module Split
           options[:metadata] = load_metadata_from_configuration
           options[:resettable] = exp_config[:resettable]
           options[:algorithm] = exp_config[:algorithm]
+          options[:friendly_name] = exp_config[:friendly_name]
         end
       end
 
@@ -261,6 +265,7 @@ module Split
       options = {
         resettable: exp_config['resettable'],
         algorithm: exp_config['algorithm'],
+        friendly_name: exp_config['friendly_name'],
         alternatives: load_alternatives_from_redis,
         goals: Split::GoalsCollection.new(@name).load_from_redis,
         metadata: load_metadata_from_redis
@@ -297,12 +302,6 @@ module Split
 
     def enable_cohorting
       redis.hset(experiment_config_key, :cohorting, false)
-    end
-
-    def friendly_name
-      return @name if metadata.nil? || metadata["friendly_name"].nil?
-
-      metadata["friendly_name"]
     end
 
     protected

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -300,6 +300,8 @@ module Split
     end
 
     def friendly_name
+      return @name if metadata.nil? || metadata["friendly_name"].nil?
+
       metadata["friendly_name"]
     end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -442,7 +442,7 @@ describe Split::Experiment do
       end
     end
 
-    context "when metadata is not defined" do
+    context "when friendly name is defined in metadata" do
       let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => { "friendly_name" => "foo" }) }
 
       it "returns the friendly name" do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -145,6 +145,13 @@ describe Split::Experiment do
         expect(Split::Experiment.new(experiment_name).friendly_name).to eq("foo")
       end
     end
+
+    context 'when no friendly name is defined' do
+      it "defaults to experiment name" do
+        experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :resettable => false)
+        expect(experiment.friendly_name).to eql("basket_text")
+      end
+    end
   end
 
   describe 'persistent configuration' do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -152,7 +152,7 @@ describe Split::Experiment do
     describe '#metadata' do
       let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => meta) }
       context 'simple hash' do
-        let(:meta) {  { 'basket' => 'a', 'cart' => 'b' } }
+        let(:meta) {  { 'basket' => 'a', 'cart' => 'b', 'friendly_name' => 'you_are_friendly' } }
         it "should persist metadata in redis" do
           experiment.save
           e = Split::ExperimentCatalog.find('basket_text')
@@ -418,6 +418,17 @@ describe Split::Experiment do
   describe "#enable_cohorting" do
     it "saves a new key in redis" do
       expect(experiment.enable_cohorting).to eq true
+    end
+  end
+
+  describe "#friendly_name" do
+    let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => meta) }
+    let(:meta) {  { 'friendly_name' => 'you_are_friendly' } }
+
+    it "should persist metadata in redis" do
+      experiment.save
+      e = Split::ExperimentCatalog.find('basket_text')
+      expect(e.friendly_name).to eql 'you_are_friendly'
     end
   end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -422,13 +422,34 @@ describe Split::Experiment do
   end
 
   describe "#friendly_name" do
-    let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => meta) }
-    let(:meta) {  { 'friendly_name' => 'you_are_friendly' } }
+    context "when metadata is not defined" do
+      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization) }
 
-    it "should persist metadata in redis" do
-      experiment.save
-      e = Split::ExperimentCatalog.find('basket_text')
-      expect(e.friendly_name).to eql 'you_are_friendly'
+      it "returns the experiment name" do
+        experiment.save
+        e = Split::ExperimentCatalog.find('basket_text')
+        expect(e.friendly_name).to eql 'basket_text'
+      end
+    end
+
+    context "when friendly name is not defined in metadata" do
+      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => {}) }
+
+      it "returns the experiment name" do
+        experiment.save
+        e = Split::ExperimentCatalog.find('basket_text')
+        expect(e.friendly_name).to eql 'basket_text'
+      end
+    end
+
+    context "when metadata is not defined" do
+      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => { "friendly_name" => "foo" }) }
+
+      it "returns the friendly name" do
+        experiment.save
+        e = Split::ExperimentCatalog.find('basket_text')
+        expect(e.friendly_name).to eql 'foo'
+      end
     end
   end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -118,13 +118,19 @@ describe Split::Experiment do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :resettable => false)
       expect(experiment.resettable).to be_falsey
     end
+
+    it "sets friendly_name" do
+      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :friendly_name => "foo")
+      expect(experiment.friendly_name).to eq("foo")
+    end
     
     context 'from configuration' do
       let(:experiment_name) { :my_experiment }
       let(:experiments) do
         {
           experiment_name => {
-            :alternatives => ['Control Opt', 'Alt one']
+            :alternatives => ['Control Opt', 'Alt one'],
+            :friendly_name => "foo"
           }
         }
       end
@@ -133,6 +139,10 @@ describe Split::Experiment do
       
       it 'assigns default values to the experiment' do
         expect(Split::Experiment.new(experiment_name).resettable).to eq(true)
+      end
+
+      it "sets friendly_name" do
+        expect(Split::Experiment.new(experiment_name).friendly_name).to eq("foo")
       end
     end
   end
@@ -418,38 +428,6 @@ describe Split::Experiment do
   describe "#enable_cohorting" do
     it "saves a new key in redis" do
       expect(experiment.enable_cohorting).to eq true
-    end
-  end
-
-  describe "#friendly_name" do
-    context "when metadata is not defined" do
-      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization) }
-
-      it "returns the experiment name" do
-        experiment.save
-        e = Split::ExperimentCatalog.find('basket_text')
-        expect(e.friendly_name).to eql 'basket_text'
-      end
-    end
-
-    context "when friendly name is not defined in metadata" do
-      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => {}) }
-
-      it "returns the experiment name" do
-        experiment.save
-        e = Split::ExperimentCatalog.find('basket_text')
-        expect(e.friendly_name).to eql 'basket_text'
-      end
-    end
-
-    context "when friendly name is defined in metadata" do
-      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => { "friendly_name" => "foo" }) }
-
-      it "returns the friendly name" do
-        experiment.save
-        e = Split::ExperimentCatalog.find('basket_text')
-        expect(e.friendly_name).to eql 'foo'
-      end
     end
   end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -152,7 +152,7 @@ describe Split::Experiment do
     describe '#metadata' do
       let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => meta) }
       context 'simple hash' do
-        let(:meta) {  { 'basket' => 'a', 'cart' => 'b', 'friendly_name' => 'you_are_friendly' } }
+        let(:meta) {  { 'basket' => 'a', 'cart' => 'b' } }
         it "should persist metadata in redis" do
           experiment.save
           e = Split::ExperimentCatalog.find('basket_text')


### PR DESCRIPTION
### What problem does this solve?
Prevents users seeing experiment names (after decoding them, for example in an email tracking request).

### How does this solve it?
By setting experiment IDs to alpha-numeric strings and using `friendly_name` on the experiment config (for the AB Tests Dashboard and Segment calls).

yaml files will then look like this:
```
exp123456:
  alternatives:
    - Control
    - Alternative
  friendly_name: "Send Activation Reminder Email Experiment"
  resettable: false
```