### PR TITLE
add user qualification

### DIFF
--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -12,7 +12,7 @@ module Split
           experiment.save
           raise(Split::InvalidExperimentsFormatError) unless (Split.configuration.experiments || {}).fetch(experiment.name.to_sym, {})[:combined_experiments].nil?
           trial = Trial.new(:user => ab_user, :experiment => experiment,
-              :override => override_alternative(experiment.name), :exclude => exclude_visitor?,
+              :override => override_alternative(experiment.name), :exclude => !is_qualified?,
               :disabled => split_generically_disabled?)
           alt = trial.choose!(self)
           alt ? alt.name : nil
@@ -160,6 +160,12 @@ module Split
 
     def control_variable(control)
       Hash === control ? control.keys.first.to_s : control.to_s
+    end
+
+    private 
+
+    def is_qualified?
+      self.respond_to?(:ab_test_user_qualified?, true) ? self.send(:ab_test_user_qualified?) : true
     end
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -262,6 +262,30 @@ describe Split::Helper do
       ab_test('link_color', 'blue', 'red')
       expect(ab_user).to eq(finished_session)
     end
+
+    context "with ab_test_user_qualified is set" do
+      context "ab_test_user_qualified returns true" do
+        def ab_test_user_qualified?
+          true 
+        end
+
+        it "user is qualified to participate in experiment" do
+          ab_test('link_color', 'blue', 'red')
+          expect(['red', 'blue']).to include(ab_user['link_color'])
+        end
+      end
+
+      context "ab_test_user_qualified returns false" do
+        def ab_test_user_qualified?
+          false 
+        end
+
+        it "user is not qualified to participate in experiment" do
+          ab_test('link_color', 'blue', 'red')
+          expect(ab_user['link_color']).to eq(nil)
+        end
+      end
+    end
   end
 
   describe 'metadata' do


### PR DESCRIPTION
In order to preserve override functionality while not enrolling the user into the experiment the Split fork needs to be amended to accommodate this change.

-  Add an optional function to be called when configured to denote whether the user should be the user should be excluded
- Replace the existing exclude_user? result passed into the Trial (currently there is a bug in split where this value is always false when passed into the newly created Trial.