### PR TITLE
Pull changes before Ruby 2.5.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Split.configure do |config|
   # before experiment reset or deleted
   config.on_before_experiment_reset  = -> (example) { # Do something on reset }
   config.on_before_experiment_delete = -> (experiment) { # Do something else on delete }
+  # after experiment winner had been set
+  config.on_experiment_winner_choose = -> (experiment) { # Do something on winner choose }
 end
 ```
 

--- a/lib/split/algorithms/whiplash.rb
+++ b/lib/split/algorithms/whiplash.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# A multi-armed bandit implementation inspired by
+# @aaronsw and victorykit/whiplash
+require 'rubystats'
+
+module Split
+  module Algorithms
+    module Whiplash
+      class << self
+        def choose_alternative(experiment)
+          experiment[best_guess(experiment.alternatives)]
+        end
+
+        private
+
+        def arm_guess(participants, completions)
+          a = [participants, 0].max
+          b = [participants-completions, 0].max
+          Rubystats::BetaDistribution.new(a+fairness_constant, b+fairness_constant).rng
+        end
+
+        def best_guess(alternatives)
+          guesses = {}
+          alternatives.each do |alternative|
+            guesses[alternative.name] = arm_guess(alternative.participant_count, alternative.all_completed_count)
+          end
+          gmax = guesses.values.max
+          best = guesses.keys.select { |name| guesses[name] ==  gmax }
+          best.sample
+        end
+
+        def fairness_constant
+          7
+        end
+      end
+    end
+  end
+end

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -20,6 +20,7 @@ module Split
     attr_accessor :on_experiment_reset
     attr_accessor :on_experiment_delete
     attr_accessor :on_before_experiment_reset
+    attr_accessor :on_experiment_winner_choose
     attr_accessor :on_before_experiment_delete
     attr_accessor :include_rails_helper
     attr_accessor :beta_probability_simulations
@@ -217,6 +218,7 @@ module Split
       @on_experiment_delete = proc{|experiment|}
       @on_before_experiment_reset = proc{|experiment|}
       @on_before_experiment_delete = proc{|experiment|}
+      @on_experiment_winner_choose = proc{|experiment|}
       @db_failover_allow_parameter_override = false
       @allow_multiple_experiments = false
       @enabled = true

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -1,15 +1,3 @@
-<% if experiment.cohorting_disabled? %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
-    <input type="hidden" name="cohorting_action" value="enable">
-    <input type="submit" value="Enable Cohorting" class="green">
-  </form>
-<% else %>
-  <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
-    <input type="hidden" name="cohorting_action" value="disable">
-    <input type="submit" value="Disable Cohorting" class="red">
-  </form>
-<% end %>
-<span class="divider">|</span>
 <% if experiment.has_winner? %>
   <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -14,7 +14,20 @@
   <form action="<%= url "/reopen?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReopen()">
     <input type="submit" value="Reopen Experiment">
   </form>
+<% else %>
+  <% if experiment.cohorting_disabled? %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmEnableCohorting()">
+      <input type="hidden" name="cohorting_action" value="enable">
+      <input type="submit" value="Enable Cohorting" class="green">
+    </form>
+  <% else %>
+    <form action="<%= url "/update_cohorting?experiment=#{experiment.name}" %>" method='post' onclick="return confirmDisableCohorting()">
+      <input type="hidden" name="cohorting_action" value="disable">
+      <input type="submit" value="Disable Cohorting" class="red">
+    </form>
+  <% end %>
 <% end %>
+<span class="divider">|</span>
 <% if experiment.start_time %>
   <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset()">
     <input type="submit" value="Reset Data">

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -53,7 +53,14 @@
       <% extra_columns.each do |column| %>
         <th><%= column %></th>
       <% end %>
-      <th>Confidence</th>
+      <th>
+        <form>
+          <select id="dropdown-<%=experiment.jstring(goal)%>" name="dropdown-<%=experiment.jstring(goal)%>">
+            <option value="confidence-<%=experiment.jstring(goal)%>">Confidence</option>
+            <option value="probability-<%=experiment.jstring(goal)%>">Probability of being Winner</option>
+          </select>
+        </form>
+      </th>
       <th>Finish</th>
     </tr>
 
@@ -87,6 +94,15 @@
             <% end  %>
           <% end %>
         </td>
+        <script type="text/javascript" id="sourcecode">
+            $(document).ready(function(){
+                $('.probability-<%=experiment.jstring(goal)%>').hide();
+                $('#dropdown-<%=experiment.jstring(goal)%>').change(function() {
+                    $('.box-<%=experiment.jstring(goal)%>').hide();
+                    $('.' + $(this).val()).show();
+                });
+            });
+        </script>
         <% extra_columns.each do |column| %>
           <td><%= alternative.extra_info && alternative.extra_info[column] %></td>
         <% end %>
@@ -94,6 +110,9 @@
           <div class="box-<%=experiment.jstring(goal)%> confidence-<%=experiment.jstring(goal)%>">
             <span title='z-score: <%= round(alternative.z_score(goal), 3) %>'><%= confidence_level(alternative.z_score(goal)) %></span>
             <br>
+          </div>
+          <div class="box-<%=experiment.jstring(goal)%> probability-<%=experiment.jstring(goal)%>">
+            <span title="p_winner: <%= round(alternative.p_winner(goal), 3) %>"><%= number_to_percentage(round(alternative.p_winner(goal), 3)) %>%</span>
           </div>
         </td>
         <td>

--- a/lib/split/dashboard/views/_experiment.erb
+++ b/lib/split/dashboard/views/_experiment.erb
@@ -4,6 +4,7 @@
   <% experiment_class = "experiment" %>
 <% end %>
 
+<% experiment.calc_winning_alternatives %>
 <%
   extra_columns = []
   experiment.alternatives.each do |alternative|

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'rubystats'
+
 module Split
   class Experiment
     attr_accessor :name
@@ -19,22 +22,7 @@ module Split
 
       @name = name.to_s
 
-      alternatives = extract_alternatives_from_options(options)
-
-      if alternatives.empty? && (exp_config = Split.configuration.experiment_for(name))
-        options = {
-          alternatives: load_alternatives_from_configuration,
-          goals: Split::GoalsCollection.new(@name).load_from_configuration,
-          metadata: load_metadata_from_configuration,
-          resettable: exp_config[:resettable],
-          algorithm: exp_config[:algorithm],
-          friendly_name: load_friendly_name_from_configuration
-        }
-      else
-        options[:alternatives] = alternatives
-      end
-
-      set_alternatives_and_options(options)
+      extract_alternatives_from_options(options)
     end
 
     def self.finished_key(key)
@@ -159,6 +147,7 @@ module Split
     def winner=(winner_name)
       redis.hset(:experiment_winner, name, winner_name.to_s)
       @has_winner = true
+      Split.configuration.on_experiment_winner_choose.call(self)
     end
 
     def participant_count
@@ -253,7 +242,7 @@ module Split
       end
       reset_winner
       redis.srem(:experiments, name)
-      redis.hdel(experiment_config_key, :cohorting)
+      remove_experiment_cohorting
       remove_experiment_configuration
       Split.configuration.on_experiment_delete.call(self)
       increment_version
@@ -278,6 +267,118 @@ module Split
       set_alternatives_and_options(options)
     end
 
+    def calc_winning_alternatives
+      # Cache the winning alternatives so we recalculate them once per the specified interval.
+      intervals_since_epoch =
+        Time.now.utc.to_i / Split.configuration.winning_alternative_recalculation_interval
+
+      if self.calc_time != intervals_since_epoch
+        if goals.empty?
+          self.estimate_winning_alternative
+        else
+          goals.each do |goal|
+            self.estimate_winning_alternative(goal)
+          end
+        end
+
+        self.calc_time = intervals_since_epoch
+
+        self.save
+      end
+    end
+
+    def estimate_winning_alternative(goal = nil)
+      # initialize a hash of beta distributions based on the alternatives' conversion rates
+      beta_params = calc_beta_params(goal)
+
+      winning_alternatives = []
+
+      Split.configuration.beta_probability_simulations.times do
+        # calculate simulated conversion rates from the beta distributions
+        simulated_cr_hash = calc_simulated_conversion_rates(beta_params)
+
+        winning_alternative = find_simulated_winner(simulated_cr_hash)
+
+        # push the winning pair to the winning_alternatives array
+        winning_alternatives.push(winning_alternative)
+      end
+
+      winning_counts = count_simulated_wins(winning_alternatives)
+
+      @alternative_probabilities = calc_alternative_probabilities(winning_counts, Split.configuration.beta_probability_simulations)
+
+      write_to_alternatives(goal)
+
+      self.save
+    end
+
+    def write_to_alternatives(goal = nil)
+      alternatives.each do |alternative|
+        alternative.set_p_winner(@alternative_probabilities[alternative], goal)
+      end
+    end
+
+    def calc_alternative_probabilities(winning_counts, number_of_simulations)
+      alternative_probabilities = {}
+      winning_counts.each do |alternative, wins|
+        alternative_probabilities[alternative] = wins / number_of_simulations.to_f
+      end
+      return alternative_probabilities
+    end
+
+    def count_simulated_wins(winning_alternatives)
+       # initialize a hash to keep track of winning alternative in simulations
+      winning_counts = {}
+      alternatives.each do |alternative|
+        winning_counts[alternative] = 0
+      end
+      # count number of times each alternative won, calculate probabilities, place in hash
+      winning_alternatives.each do |alternative|
+        winning_counts[alternative] += 1
+      end
+      return winning_counts
+    end
+
+    def find_simulated_winner(simulated_cr_hash)
+      # figure out which alternative had the highest simulated conversion rate
+      winning_pair = ["",0.0]
+      simulated_cr_hash.each do |alternative, rate|
+        if rate > winning_pair[1]
+          winning_pair = [alternative, rate]
+        end
+      end
+      winner = winning_pair[0]
+      return winner
+    end
+
+    def calc_simulated_conversion_rates(beta_params)
+      simulated_cr_hash = {}
+
+      # create a hash which has the conversion rate pulled from each alternative's beta distribution
+      beta_params.each do |alternative, params|
+        alpha = params[0]
+        beta = params[1]
+        simulated_conversion_rate = Rubystats::BetaDistribution.new(alpha, beta).rng
+        simulated_cr_hash[alternative] = simulated_conversion_rate
+      end
+
+      return simulated_cr_hash
+    end
+
+    def calc_beta_params(goal = nil)
+      beta_params = {}
+      alternatives.each do |alternative|
+        conversions = goal.nil? ? alternative.completed_count : alternative.completed_count(goal)
+        alpha = 1 + conversions
+        beta = 1 + alternative.participant_count - conversions
+
+        params = [alpha, beta]
+
+        beta_params[alternative] = params
+      end
+      return beta_params
+    end
+
     def calc_time=(time)
       redis.hset(experiment_config_key, :calc_time, time)
     end
@@ -296,15 +397,19 @@ module Split
     end
 
     def cohorting_disabled?
-      value = redis.hget(experiment_config_key, :cohorting)
-      value.nil? ? false : value.downcase == "true"
+      @cohorting_disabled ||= begin
+        value = redis.hget(experiment_config_key, :cohorting)
+        value.nil? ? false : value.downcase == "true"
+      end
     end
 
     def disable_cohorting
+      @cohorting_disabled = true
       redis.hset(experiment_config_key, :cohorting, true)
     end
 
     def enable_cohorting
+      @cohorting_disabled = false
       redis.hset(experiment_config_key, :cohorting, false)
     end
 
@@ -397,6 +502,11 @@ module Split
 
     def goals_collection
       Split::GoalsCollection.new(@name, @goals)
+    end
+
+    def remove_experiment_cohorting
+      @cohorting_disabled = false
+      redis.hdel(experiment_config_key, :cohorting)
     end
   end
 end

--- a/lib/split/helper.rb
+++ b/lib/split/helper.rb
@@ -32,8 +32,8 @@ module Split
       end
 
       if block_given?
-        metadata = trial ? trial.metadata : {}
-        yield(alternative, metadata)
+        metadata = experiment.metadata[alternative] if experiment.metadata
+        yield(alternative, metadata || {})
       else
         alternative
       end

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -91,9 +91,11 @@ module Split
         end
       end
 
-      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || (new_participant && @experiment.cohorting_disabled?)
+      new_participant_and_cohorting_disabled = new_participant && @experiment.cohorting_disabled?
+
+      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || new_participant_and_cohorting_disabled
       @alternative_choosen = true
-      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || (new_participant && @experiment.cohorting_disabled?) 
+      run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || new_participant_and_cohorting_disabled
       alternative
     end
 

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -27,7 +27,8 @@ module Split
     def max_experiments_reached?(experiment_key)
       if Split.configuration.allow_multiple_experiments == 'control'
         experiments = active_experiments
-        count_control = experiments.count {|k,v| k == experiment_key || v == 'control'}
+        experiment_key_without_version = key_without_version(experiment_key)
+        count_control = experiments.count {|k,v| k == experiment_key_without_version || v == 'control'}
         experiments.size > count_control
       else
         !Split.configuration.allow_multiple_experiments &&

--- a/spec/algorithms/whiplash_spec.rb
+++ b/spec/algorithms/whiplash_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Split::Algorithms::Whiplash do
+
+  it "should return an algorithm" do
+    experiment = Split::ExperimentCatalog.find_or_create('link_color', {'blue' => 1}, {'red' => 1 })
+    expect(Split::Algorithms::Whiplash.choose_alternative(experiment).class).to eq(Split::Alternative)
+  end
+
+  it "should return one of the results" do
+    experiment = Split::ExperimentCatalog.find_or_create('link_color', {'blue' => 1}, {'red' => 1 })
+    expect(['red', 'blue']).to include Split::Algorithms::Whiplash.choose_alternative(experiment).name
+  end
+
+  it "should guess floats" do
+    expect(Split::Algorithms::Whiplash.send(:arm_guess, 0, 0).class).to eq(Float)
+    expect(Split::Algorithms::Whiplash.send(:arm_guess, 1, 0).class).to eq(Float)
+    expect(Split::Algorithms::Whiplash.send(:arm_guess, 2, 1).class).to eq(Float)
+    expect(Split::Algorithms::Whiplash.send(:arm_guess, 1000, 5).class).to eq(Float)
+    expect(Split::Algorithms::Whiplash.send(:arm_guess, 10, -2).class).to eq(Float)
+  end
+
+end

--- a/spec/encapsulated_helper_spec.rb
+++ b/spec/encapsulated_helper_spec.rb
@@ -21,7 +21,7 @@ describe Split::EncapsulatedHelper do
     end
 
     it "calls the block with selected alternative" do
-      expect{|block| ab_test('link_color', 'red', 'red', &block) }.to yield_with_args('red', nil)
+      expect{|block| ab_test('link_color', 'red', 'red', &block) }.to yield_with_args('red', {})
     end
 
     context "inside a view" do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -123,7 +123,7 @@ describe Split::Experiment do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :friendly_name => "foo")
       expect(experiment.friendly_name).to eq("foo")
     end
-    
+
     context 'from configuration' do
       let(:experiment_name) { :my_experiment }
       let(:experiments) do
@@ -136,7 +136,7 @@ describe Split::Experiment do
       end
 
       before { Split.configuration.experiments = experiments }
-      
+
       it 'assigns default values to the experiment' do
         expect(Split::Experiment.new(experiment_name).resettable).to eq(true)
       end
@@ -256,10 +256,15 @@ describe Split::Experiment do
   end
 
   describe 'winner=' do
-    it "should allow you to specify a winner" do
+    it 'should allow you to specify a winner' do
       experiment.save
       experiment.winner = 'red'
       expect(experiment.winner.name).to eq('red')
+    end
+
+    it 'should call the on_experiment_winner_choose hook' do
+      expect(Split.configuration.on_experiment_winner_choose).to receive(:call)
+      experiment.winner = 'green'
     end
 
     context 'when has_winner state is memoized' do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -56,7 +56,7 @@ describe Split::Experiment do
     end
 
     it "should save the selected algorithm to redis" do
-      experiment_algorithm = Split::Algorithms::BlockRandomization
+      experiment_algorithm = Split::Algorithms::Whiplash
       experiment.algorithm = experiment_algorithm
       experiment.save
 
@@ -110,8 +110,8 @@ describe Split::Experiment do
 
   describe 'initialization' do
     it "should set the algorithm when passed as an option to the initializer" do
-       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm =>  Split::Algorithms::BlockRandomization)
-       expect(experiment.algorithm).to eq(Split::Algorithms::BlockRandomization)
+       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm =>  Split::Algorithms::Whiplash)
+       expect(experiment.algorithm).to eq(Split::Algorithms::Whiplash)
     end
 
     it "should be possible to make an experiment not resettable" do
@@ -167,7 +167,7 @@ describe Split::Experiment do
     end
 
     describe '#metadata' do
-      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization, :metadata => meta) }
+      let(:experiment) { Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::Whiplash, :metadata => meta) }
       context 'simple hash' do
         let(:meta) {  { 'basket' => 'a', 'cart' => 'b' } }
         it "should persist metadata in redis" do
@@ -190,16 +190,16 @@ describe Split::Experiment do
     end
 
     it "should persist algorithm in redis" do
-      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::BlockRandomization)
+      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :algorithm => Split::Algorithms::Whiplash)
       experiment.save
 
       e = Split::ExperimentCatalog.find('basket_text')
       expect(e).to eq(experiment)
-      expect(e.algorithm).to eq(Split::Algorithms::BlockRandomization)
+      expect(e.algorithm).to eq(Split::Algorithms::Whiplash)
     end
 
     it "should persist a new experiment in redis, that does not exist in the configuration file" do
-      experiment = Split::Experiment.new('foobar', :alternatives => ['tra', 'la'], :algorithm => Split::Algorithms::BlockRandomization)
+      experiment = Split::Experiment.new('foobar', :alternatives => ['tra', 'la'], :algorithm => Split::Algorithms::Whiplash)
       experiment.save
 
       e = Split::ExperimentCatalog.find('foobar')
@@ -375,8 +375,8 @@ describe Split::Experiment do
     end
 
     it 'should use the user specified algorithm for this experiment if specified' do
-      experiment.algorithm = Split::Algorithms::BlockRandomization
-      expect(experiment.algorithm).to eq(Split::Algorithms::BlockRandomization)
+      experiment.algorithm = Split::Algorithms::Whiplash
+      expect(experiment.algorithm).to eq(Split::Algorithms::Whiplash)
     end
   end
 
@@ -398,7 +398,7 @@ describe Split::Experiment do
 
       context 'without winner' do
         it "should use the specified algorithm" do
-          experiment.algorithm = Split::Algorithms::BlockRandomization
+          experiment.algorithm = Split::Algorithms::Whiplash
           expect(experiment.algorithm).to receive(:choose_alternative).and_return(Split::Alternative.new('green', 'link_color'))
           expect(experiment.next_alternative.name).to eq('green')
         end
@@ -548,6 +548,42 @@ describe Split::Experiment do
         experiment = Split::ExperimentCatalog.find_or_create('link_color3', 'blue', 'red', 'green')
         expect(experiment.goals).to eq([])
       end
+    end
+  end
+
+  describe "beta probability calculation" do
+    it "should return a hash with the probability of each alternative being the best" do
+      experiment = Split::ExperimentCatalog.find_or_create('mathematicians', 'bernoulli', 'poisson', 'lagrange')
+      experiment.calc_winning_alternatives
+      expect(experiment.alternative_probabilities).not_to be_nil
+    end
+
+    it "should return between 46% and 54% probability for an experiment with 2 alternatives and no data" do
+      experiment = Split::ExperimentCatalog.find_or_create('scientists', 'einstein', 'bohr')
+      experiment.calc_winning_alternatives
+      expect(experiment.alternatives[0].p_winner).to be_within(0.04).of(0.50)
+    end
+
+    it "should calculate the probability of being the winning alternative separately for each goal", :skip => true do
+      experiment = Split::ExperimentCatalog.find_or_create({'link_color3' => ["purchase", "refund"]}, 'blue', 'red', 'green')
+      goal1 = experiment.goals[0]
+      goal2 = experiment.goals[1]
+      experiment.alternatives.each do |alternative|
+        alternative.participant_count = 50
+        alternative.set_completed_count(10, goal1)
+        alternative.set_completed_count(15+rand(30), goal2)
+      end
+      experiment.calc_winning_alternatives
+      alt = experiment.alternatives[0]
+      p_goal1 = alt.p_winner(goal1)
+      p_goal2 = alt.p_winner(goal2)
+      expect(p_goal1).not_to be_within(0.04).of(p_goal2)
+    end
+
+    it "should return nil and not re-calculate probabilities if they have already been calculated today" do
+      experiment = Split::ExperimentCatalog.find_or_create({'link_color3' => ["purchase", "refund"]}, 'blue', 'red', 'green')
+      expect(experiment.calc_winning_alternatives).not_to be nil
+      expect(experiment.calc_winning_alternatives).to be nil
     end
   end
 end

--- a/split.gemspec
+++ b/split.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'redis',           '>= 2.1'
   s.add_dependency 'sinatra',         '>= 1.2.6'
+  s.add_dependency 'rubystats',       '>= 0.3.0'
 
   s.add_development_dependency 'bundler',     '>= 1.17'
   s.add_development_dependency 'simplecov',   '~> 0.15'


### PR DESCRIPTION
### What is this?
Merges the changes from upstream Split repo, just before Split requires Ruby 2.5.0 (which we do not yet support in Manage).

### Why is it important?
So we can incrementally merge smaller diffs from upstream Split repo (to avoid large merges and ultimately increased divergence).