### PR TITLE
Cleanup time of assignment and cleanup specs

### DIFF
--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -19,6 +19,7 @@ module Split
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
           user.delete Experiment.finished_key(key)
+          user.delete "#{key}:time_of_assignment"
         end
       end
       @cleaned_up = true

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -54,7 +54,7 @@ describe Split::User do
       expect(@subject.keys).to be_empty
     end
 
-    it 'keeps keys if the experiment has no winnder and has started' do
+    it 'keeps keys if the experiment has no winner and has started' do
       allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
       allow(experiment).to receive(:has_winner?).and_return(false)
       allow(experiment).to receive(:start_time).and_return(Date.today)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -26,52 +26,44 @@ describe Split::User do
   end 
 
   context '#cleanup_old_experiments!' do
-    it 'removes key if experiment is not found' do
+    let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => true, 'link_color:time_of_assignment' => Time.now.to_s } }
+
+    it 'removes keys if experiment is not found' do
       @subject.cleanup_old_experiments!
+      
       expect(@subject.keys).to be_empty
     end
 
-    it 'removes key if experiment has a winner' do
+    it 'removes keys if experiment has a winner' do
       allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-      allow(experiment).to receive(:start_time).and_return(Date.today)
       allow(experiment).to receive(:has_winner?).and_return(true)
+      allow(experiment).to receive(:start_time).and_return(Date.today)
+      
       @subject.cleanup_old_experiments!
+      
       expect(@subject.keys).to be_empty
     end
 
-    it 'removes key if experiment has not started yet' do
+    it 'removes keys if experiment has not started yet' do
       allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
       allow(experiment).to receive(:has_winner?).and_return(false)
+      allow(experiment).to receive(:start_time).and_return(nil)
+      
       @subject.cleanup_old_experiments!
+      
       expect(@subject.keys).to be_empty
     end
 
-    context 'with finished key' do
-      let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => true } }
-
-      it 'does not remove finished key for experiment without a winner' do
-        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-        allow(Split::ExperimentCatalog).to receive(:find).with('link_color:finished').and_return(nil)
-        allow(experiment).to receive(:start_time).and_return(Date.today)
-        allow(experiment).to receive(:has_winner?).and_return(false)
-        @subject.cleanup_old_experiments!
-        expect(@subject.keys).to include("link_color")
-        expect(@subject.keys).to include("link_color:finished")
-      end
-    end
-
-    context 'with time_of_assignment key' do
-      let(:user_keys) { { 'link_color' => 'blue', 'link_color:time_of_assignment' => true } }
-
-      it 'does not remove time_of_assignment key' do
-        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-        allow(Split::ExperimentCatalog).to receive(:find).with('link_color:time_of_assignment').and_return(nil)
-        allow(experiment).to receive(:start_time).and_return(Date.today)
-        allow(experiment).to receive(:has_winner?).and_return(false)
-        @subject.cleanup_old_experiments!
-        expect(@subject.keys).to include("link_color")
-        expect(@subject.keys).to include("link_color:time_of_assignment")
-      end
+    it 'keeps keys if the experiment has no winnder and has started' do
+      allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+      allow(experiment).to receive(:has_winner?).and_return(false)
+      allow(experiment).to receive(:start_time).and_return(Date.today)
+      
+      @subject.cleanup_old_experiments!
+      
+      expect(@subject.keys).to include("link_color")
+      expect(@subject.keys).to include("link_color:finished")
+      expect(@subject.keys).to include("link_color:time_of_assignment")
     end
 
     context 'when already cleaned up' do


### PR DESCRIPTION
### What problem does this solve?
When an experiment is completed, and a user is cohorted into a new experiment the cleanup is run. The old experiment `time_of_assignment` for the user is not removed and is left dangling until it expires.

### How does this solve it?
- Removes the time_of_assignment redis key from the user's keys if the experiment no longer exists, has a winner, or hasn't started.
- Cleans-up the spec