### PR TITLE
Fix whiplash namespacing

### DIFF
--- a/lib/split.rb
+++ b/lib/split.rb
@@ -3,6 +3,7 @@ require 'redis'
 
 require 'split/algorithms/block_randomization'
 require 'split/algorithms/weighted_sample'
+require 'split/algorithms/whiplash'
 require 'split/alternative'
 require 'split/configuration'
 require 'split/encapsulated_helper'


### PR DESCRIPTION
### What problem does this solve?
Running rspec will fail because whiplash is not properly loaded

### How does this solve it?
- readds `require 'split/algorithms/whiplash'` that was removed in https://github.com/clio/split/pull/1