### PR TITLE
Preserve cohorts existing cohorts after resets

### DIFF
--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -163,7 +163,8 @@ module Split
           metadata: value_for(settings, :metadata),
           algorithm: value_for(settings, :algorithm),
           resettable: value_for(settings, :resettable),
-          friendly_name: value_for(settings, :friendly_name)
+          friendly_name: value_for(settings, :friendly_name),
+          retain_user_alternatives_after_reset:  value_for(settings, :retain_user_alternatives_after_reset)
         }
 
         experiment_data.each do |name, value|

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -37,7 +37,8 @@ module Split
 
     def complete!(context = nil)
       if alternative
-        if within_conversion_time_frame?
+        # if the current key matches the user experiment key then the user is on the current version of the experiment
+        if within_conversion_time_frame? && @experiment.key == user_experiment_key
           if Array(goals).empty?
             alternative.increment_completion
           else
@@ -58,10 +59,11 @@ module Split
       # Only run the process once
       return alternative if @alternative_choosen
 
-      new_participant = @user[@experiment.key].nil?
+      user_experiment_key = @experiment.retain_user_alternatives_after_reset ? @user.alternative_key_for_experiment(@experiment) : @experiment.key
+      new_participant = @user[user_experiment_key].nil?
       if override_is_alternative?
         self.alternative = @options[:override]
-        if should_store_alternative? && !@user[@experiment.key]
+        if should_store_alternative? && !@user[user_experiment_key]
           self.alternative.increment_participation
         end
       elsif @options[:disabled] || Split.configuration.disabled?
@@ -69,12 +71,12 @@ module Split
       elsif @experiment.has_winner?
         self.alternative = @experiment.winner
       else
-        cleanup_old_versions
+        cleanup_old_versions unless experiment.retain_user_alternatives_after_reset
 
         if exclude_user?
           self.alternative = @experiment.control
         else
-          self.alternative = @user[@experiment.key]
+          self.alternative = @user[user_experiment_key]
           if alternative.nil?
             if @experiment.cohorting_disabled?
               self.alternative = @experiment.control
@@ -93,11 +95,13 @@ module Split
 
       new_participant_and_cohorting_disabled = new_participant && @experiment.cohorting_disabled?
 
-      @user[@experiment.key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || new_participant_and_cohorting_disabled
+      @user[user_experiment_key] = alternative.name unless @experiment.has_winner? || !should_store_alternative? || new_participant_and_cohorting_disabled
       @alternative_choosen = true
       run_callback context, Split.configuration.on_trial unless @options[:disabled] || Split.configuration.disabled? || new_participant_and_cohorting_disabled
       alternative
     end
+
+    private
 
     def within_conversion_time_frame?
       if !@within_conversion_time_frame.nil?
@@ -108,20 +112,22 @@ module Split
 
           return true if window_of_time_for_conversion_in_minutes.nil?
 
-          time_of_assignment = Time.parse(@user["#{@experiment.key}:time_of_assignment"])
+          time_of_assignment = Time.parse(@user["#{user_experiment_key}:time_of_assignment"])
           (Time.now - time_of_assignment)/60 <= window_of_time_for_conversion_in_minutes
         end
       end
     end
 
-    private
+    def user_experiment_key
+      @user_experiment_key ||= @user.alternative_key_for_experiment(@experiment)
+    end
 
     def delete_time_of_assignment_key
-      @user.delete("#{@experiment.key}:time_of_assignment")
+      @user.delete("#{user_experiment_key}:time_of_assignment")
     end
 
     def save_time_that_user_is_assigned
-      @user["#{@experiment.key}:time_of_assignment"] = Time.now.to_s
+      @user["#{user_experiment_key}:time_of_assignment"] = Time.now.to_s
     end
 
     def run_callback(context, callback_name)

--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -101,8 +101,6 @@ module Split
       alternative
     end
 
-    private
-
     def within_conversion_time_frame?
       if !@within_conversion_time_frame.nil?
         @within_conversion_time_frame
@@ -117,6 +115,8 @@ module Split
         end
       end
     end
+
+    private
 
     def user_experiment_key
       @user_experiment_key ||= @user.alternative_key_for_experiment(@experiment)

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -54,6 +54,32 @@ module Split
       experiment_pairs
     end
 
+    def alternative_key_for_experiment(experiment)
+      if experiment.version > 0
+        keys = user.keys
+
+        #default to current experiment key when one isn't found
+        user_experiment_key = experiment.key
+
+        #first version is not colon delimited 
+        if keys.include?(experiment.name)
+          user_experiment_key = experiment.name
+        else
+          experiment.version.times do |version_number|
+            key = "#{experiment.name}:#{version_number+1}"
+            if keys.include?(key)
+              user_experiment_key = key
+              break
+            end
+          end
+        end
+
+        user_experiment_key
+      else
+        experiment.key
+      end
+    end
+
     private
 
     def keys_without_experiment(keys, experiment_key)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -82,12 +82,13 @@ describe Split::Configuration do
                 - Alt One
                 - Alt Two
               resettable: false
+              retain_user_alternatives_after_reset: true
             eos
           @config.experiments = YAML.load(experiments_yaml)
         end
 
         it 'should normalize experiments' do
-          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:alternatives=>["Control Opt", ["Alt One", "Alt Two"]]}})
+          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:retain_user_alternatives_after_reset=>true,:alternatives=>["Control Opt", ["Alt One", "Alt Two"]]}})
         end
       end
 
@@ -133,6 +134,7 @@ describe Split::Configuration do
                 - name: Alt Two
                   percent: 23
               resettable: false
+              retain_user_alternatives_after_reset: true
               metric: my_metric
             another_experiment:
               alternatives:
@@ -143,7 +145,7 @@ describe Split::Configuration do
         end
 
         it "should normalize experiments" do
-          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:alternatives=>[{"Control Opt"=>0.67},
+          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:retain_user_alternatives_after_reset=>true,:alternatives=>[{"Control Opt"=>0.67},
             [{"Alt One"=>0.1}, {"Alt Two"=>0.23}]]}, :another_experiment=>{:alternatives=>["a", ["b"]]}})
         end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -124,7 +124,7 @@ describe Split::Experiment do
     end
 
     it "should be possible to make an experiment retain user alternatives after reset" do
-      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :retain_user_alternatives_after_reset => true)
+      experiment = Split::Experiment.new("basket_text", :alternatives => ["Basket", "Cart"], :retain_user_alternatives_after_reset => true)
       expect(experiment.resettable).to be_truthy
     end
 
@@ -177,10 +177,10 @@ describe Split::Experiment do
     end
 
     it "should persist retain_user_alternatives_after_reset in redis" do
-      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :retain_user_alternatives_after_reset => true)
+      experiment = Split::Experiment.new("basket_text", :alternatives => ['Basket', "Cart"], :retain_user_alternatives_after_reset => true)
       experiment.save
 
-      e = Split::ExperimentCatalog.find('basket_text')
+      e = Split::ExperimentCatalog.find("basket_text")
       expect(e).to eq(experiment)
       expect(e.retain_user_alternatives_after_reset).to be_truthy
     end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -125,7 +125,7 @@ describe Split::Experiment do
 
     it "should be possible to make an experiment retain user alternatives after reset" do
       experiment = Split::Experiment.new("basket_text", :alternatives => ["Basket", "Cart"], :retain_user_alternatives_after_reset => true)
-      expect(experiment.resettable).to be_truthy
+      expect(experiment.retain_user_alternatives_after_reset).to be_truthy
     end
 
     it "sets friendly_name" do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -35,6 +35,10 @@ describe Split::Experiment do
       expect(experiment.resettable).to be_truthy
     end
 
+    it "should not retain user alternatives after reset by default" do
+      expect(experiment.retain_user_alternatives_after_reset).to be_falsey
+    end
+
     it "should save to redis" do
       experiment.save
       expect(Split.redis.exists('basket_text')).to be true
@@ -119,6 +123,11 @@ describe Split::Experiment do
       expect(experiment.resettable).to be_falsey
     end
 
+    it "should be possible to make an experiment retain user alternatives after reset" do
+      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :retain_user_alternatives_after_reset => true)
+      expect(experiment.resettable).to be_truthy
+    end
+
     it "sets friendly_name" do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :friendly_name => "foo")
       expect(experiment.friendly_name).to eq("foo")
@@ -139,6 +148,7 @@ describe Split::Experiment do
 
       it 'assigns default values to the experiment' do
         expect(Split::Experiment.new(experiment_name).resettable).to eq(true)
+        expect(Split::Experiment.new(experiment_name).retain_user_alternatives_after_reset).to eq(false)
       end
 
       it "sets friendly_name" do
@@ -164,6 +174,15 @@ describe Split::Experiment do
       expect(e).to eq(experiment)
       expect(e.resettable).to be_falsey
 
+    end
+
+    it "should persist retain_user_alternatives_after_reset in redis" do
+      experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :retain_user_alternatives_after_reset => true)
+      experiment.save
+
+      e = Split::ExperimentCatalog.find('basket_text')
+      expect(e).to eq(experiment)
+      expect(e.retain_user_alternatives_after_reset).to be_truthy
     end
 
     describe '#metadata' do
@@ -377,6 +396,34 @@ describe Split::Experiment do
     it 'should use the user specified algorithm for this experiment if specified' do
       experiment.algorithm = Split::Algorithms::Whiplash
       expect(experiment.algorithm).to eq(Split::Algorithms::Whiplash)
+    end
+  end
+
+  describe "#retain_user_alternatives_after_reset=" do
+    let(:experiment) { Split::ExperimentCatalog.find_or_create("link_color", "blue", "red", "green") }
+
+    it "should accept and return true if given string true" do
+      experiment.retain_user_alternatives_after_reset = "true"
+
+      expect(experiment.retain_user_alternatives_after_reset).to be true
+    end
+
+    it "should accept and return true if given true" do
+      experiment.retain_user_alternatives_after_reset = true
+
+      expect(experiment.retain_user_alternatives_after_reset).to be true
+    end
+
+    it "should accept and return false if given anything but true" do
+      experiment.retain_user_alternatives_after_reset = "invalid boolean"
+
+      expect(experiment.retain_user_alternatives_after_reset).to be false
+    end
+
+    it "should accept and return false if given false" do
+      experiment.retain_user_alternatives_after_reset = false
+
+      expect(experiment.retain_user_alternatives_after_reset).to be false
     end
   end
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -371,10 +371,54 @@ describe Split::Helper do
         @previous_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
       end
 
-      it 'should increment the counter for the completed alternative' do
-        ab_finished(@experiment_name)
-        new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
-        expect(new_completion_count).to eq(@previous_completion_count + 1)
+      context "when the user is in a previous version of the experiment and retain_user_alternatives_after_reset is true" do
+        before do
+          @experiment.retain_user_alternatives_after_reset = true
+          @experiment.increment_version
+        end
+
+        it 'should not increment the counter for the completed alternative' do
+          ab_finished(@experiment_name)
+          new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
+          expect(new_completion_count).to eq(@previous_completion_count)
+        end
+      end
+
+      context "when the user is in current version of the experiment and retain_user_alternatives_after_reset is true" do
+        before do
+          @experiment.retain_user_alternatives_after_reset = true
+        end
+
+        it 'should increment the counter for the completed alternative' do
+          ab_finished(@experiment_name)
+          new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
+          expect(new_completion_count).to eq(@previous_completion_count + 1)
+        end
+      end
+
+      context "when the user is in a previous version of the experiment and retain_user_alternatives_after_reset is false" do
+         before do
+          @experiment.retain_user_alternatives_after_reset = false
+          @experiment.increment_version
+        end
+
+        it 'should not increment the counter for the completed alternative' do
+          ab_finished(@experiment_name)
+          new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
+          expect(new_completion_count).to eq(@previous_completion_count)
+        end
+      end
+
+      context "when the user is in current version of the experiment and retain_user_alternatives_after_reset is false" do
+        before do
+          @experiment.retain_user_alternatives_after_reset = false
+        end
+
+        it 'should increment the counter for the completed alternative' do
+          ab_finished(@experiment_name)
+          new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
+          expect(new_completion_count).to eq(@previous_completion_count + 1)
+        end
       end
 
       it "should set experiment's finished key if reset is false" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -377,7 +377,7 @@ describe Split::Helper do
           @experiment.increment_version
         end
 
-        it 'should not increment the counter for the completed alternative' do
+        it "increments the counter for the completed alternative" do
           ab_finished(@experiment_name)
           new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
           expect(new_completion_count).to eq(@previous_completion_count)
@@ -389,7 +389,7 @@ describe Split::Helper do
           @experiment.retain_user_alternatives_after_reset = true
         end
 
-        it 'should increment the counter for the completed alternative' do
+        it "increments the counter for the completed alternative" do
           ab_finished(@experiment_name)
           new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
           expect(new_completion_count).to eq(@previous_completion_count + 1)
@@ -402,7 +402,7 @@ describe Split::Helper do
           @experiment.increment_version
         end
 
-        it 'should not increment the counter for the completed alternative' do
+        it "does not increment the counter for the completed alternative" do
           ab_finished(@experiment_name)
           new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
           expect(new_completion_count).to eq(@previous_completion_count)
@@ -414,7 +414,7 @@ describe Split::Helper do
           @experiment.retain_user_alternatives_after_reset = false
         end
 
-        it 'should increment the counter for the completed alternative' do
+        it "increments the counter for the completed alternative" do
           ab_finished(@experiment_name)
           new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
           expect(new_completion_count).to eq(@previous_completion_count + 1)

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -184,6 +184,120 @@ describe Split::Trial do
           expect_alternative(trial, alternatives)
         end
       end
+
+      context "when the user is in a previous version of the experiment and retain_user_alternatives_after_reset is true" do
+        before do
+          user[experiment.name] = "basket"
+
+          experiment.retain_user_alternatives_after_reset = true
+          experiment.increment_version
+        end
+
+        it "does not clean up previous version of the experiment" do
+          expect(user[experiment.name]).to eq("basket")
+
+          trial.choose!
+          
+          expect(user[experiment.name]).to eq("basket")
+        end
+
+        it "does not create new version of the experiment" do
+          expect(user[experiment.key]).to be nil
+
+          trial.choose!
+          
+          expect(user[experiment.key]).to be nil
+        end
+
+        it "does not increment the participant count" do
+          original_count = experiment.participant_count
+
+          trial.choose!
+
+          expect(experiment.participant_count).to eql(original_count)
+        end
+      end
+
+      context "when the user is in a previous version of the experiment and retain_user_alternatives_after_reset is false" do
+         before do
+          user[experiment.name] = "basket"
+
+          experiment.retain_user_alternatives_after_reset = false
+          experiment.increment_version
+        end
+
+        it "cleans up old version of the experiment" do
+          expect(user[experiment.name]).to eq("basket")
+
+          trial.choose!
+          
+          expect(user[experiment.name]).to be nil
+        end
+
+        it "creates new version of the experiment" do
+          expect(user[experiment.key]).to be nil
+
+          trial.choose!
+          
+          expect(["basket", "cart"]).to include(user[experiment.key])
+        end
+
+        it "increments the participant count" do
+          original_count = experiment.participant_count
+
+          trial.choose!
+
+          expect(experiment.participant_count).to eql(original_count + 1)
+        end
+      end
+
+      context "when the user is in current version of the experiment and retain_user_alternatives_after_reset is true" do
+        before do
+          user[experiment.name] = "basket"
+
+          experiment.retain_user_alternatives_after_reset = true
+        end
+
+        it "does not increment the participant count" do
+          original_count = experiment.participant_count
+
+          trial.choose!
+
+          expect(experiment.participant_count).to eql(original_count)
+        end
+
+         it "does not clean up previous version of the experiment" do
+          expect(user[experiment.key]).to eq("basket")
+
+          trial.choose!
+          
+          expect(user[experiment.key]).to eq("basket")
+        end
+      end
+
+      context "when the user is in current version of the experiment and retain_user_alternatives_after_reset is false" do
+        before do
+          user[experiment.name] = "basket"
+
+          experiment.retain_user_alternatives_after_reset = false
+        end
+
+        it "does not increment the participant count" do
+          original_count = experiment.participant_count
+
+          trial.choose!
+
+          expect(experiment.participant_count).to eql(original_count)
+        end
+
+        it "does not clean up previous version of the experiment" do
+          expect(user[experiment.key]).to eq("basket")
+
+          trial.choose!
+          
+          expect(user[experiment.key]).to eq("basket")
+        end
+      end
     end
 
     context "when user is a new participant" do
@@ -242,24 +356,40 @@ describe Split::Trial do
       expect(user[experiment.key + ":time_of_assignment"]).to be nil
     end
 
-    context "and the user is not within the conversion time frame" do
-      it "does not convert" do
-        old_completed_count = trial.alternative.completed_count
+    it "does not not convert when the user is not within the conversion time frame and experiment key is not the same as the user key" do
+      allow(Time).to receive(:now).and_return(Time.now + 60*120)
+      experiment.increment_version # this will change the experiment key to "basket_text:1"
 
-        allow(Time).to receive(:now).and_return(Time.now + 60*120)
+      old_completed_count = trial.alternative.completed_count
 
-        trial.complete!
-        expect(trial.alternative.completed_count).to be(old_completed_count)
-      end
+      trial.complete!
+      expect(trial.alternative.completed_count).to be(old_completed_count)
+  
     end
 
-    context "and the user is within the conversion time frame" do
-      it "does convert" do
-        old_completed_count = trial.alternative.completed_count
+    it "does not convert when the user is not within the conversion time frame and experiment key is the same as the user key" do
+      old_completed_count = trial.alternative.completed_count
 
-        trial.complete!
-        expect(trial.alternative.completed_count).to be(old_completed_count+1)
-      end
+      allow(Time).to receive(:now).and_return(Time.now + 60*120)
+
+      trial.complete!
+      expect(trial.alternative.completed_count).to be(old_completed_count)
+    end
+
+    it "does not converts when the user is within the conversion time frame and experiment key is not the same as the user key" do
+      experiment.increment_version # this will change the experiment key to "basket_text:1"
+      
+      old_completed_count = trial.alternative.completed_count
+
+      trial.complete!
+      expect(trial.alternative.completed_count).to be(old_completed_count)
+    end
+
+    it "converts when the user is within the conversion time frame and experiment key is the same as the user key" do
+      old_completed_count = trial.alternative.completed_count
+
+      trial.complete!
+      expect(trial.alternative.completed_count).to be(old_completed_count+1)
     end
 
     context 'when there are no goals' do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -89,7 +89,7 @@ describe Split::User do
       before { 2.times { experiment.increment_version } }
 
       context "user has a key from a first version of the experiment" do
-        let(:user_keys) { { 'link_color' => 'blue' } }
+        let(:user_keys) { { "link_color" => "blue" } }
 
         it "returns the current experiment key" do
           expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color")
@@ -97,7 +97,7 @@ describe Split::User do
       end
 
       context "user has a key from a previous version of the experiment" do
-        let(:user_keys) { { 'link_color:1' => 'blue' } }
+        let(:user_keys) { { "link_color:1" => "blue" } }
 
         it "returns the current experiment key" do
           expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color:1")
@@ -105,7 +105,7 @@ describe Split::User do
       end
 
       context "user has the same key as the current version of the experiment" do 
-        let(:user_keys) { { 'link_color:2' => 'blue' } }
+        let(:user_keys) { { "link_color:2" => "blue" } }
 
         it "returns the current experiment key" do
           expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color:2")

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -78,6 +78,50 @@ describe Split::User do
     end
   end
 
+  context "#alternative_key_for_experiment" do
+    context "if there is only 1 version of the experiment" do
+      it "returns the current experiment key" do
+        expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color")
+      end
+    end
+
+    context "if there are multiple versions of the experiment" do
+      before { 2.times { experiment.increment_version } }
+
+      context "user has a key from a first version of the experiment" do
+        let(:user_keys) { { 'link_color' => 'blue' } }
+
+        it "returns the current experiment key" do
+          expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color")
+        end
+      end
+
+      context "user has a key from a previous version of the experiment" do
+        let(:user_keys) { { 'link_color:1' => 'blue' } }
+
+        it "returns the current experiment key" do
+          expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color:1")
+        end
+      end
+
+      context "user has the same key as the current version of the experiment" do 
+        let(:user_keys) { { 'link_color:2' => 'blue' } }
+
+        it "returns the current experiment key" do
+          expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color:2")
+        end
+      end
+
+      context "user does not have any key for the experiment" do 
+        let(:user_keys) { { } }
+
+        it "returns the current experiment key" do
+          expect(@subject.alternative_key_for_experiment(experiment)).to eq("link_color:2")
+        end
+      end
+    end
+  end
+
   context "instantiated with custom adapter" do
     let(:custom_adapter) { double(:persistence_adapter) }
 


### PR DESCRIPTION
### What problem does this solve?
Resetting experiments can be costly and annoying as we have to redeploy a new experiment config and update the code base to support the original experiment id and the new one. Split has functionality to reset experiments however it does not support the ability to preserve the original cohorted users alternative.

### How does this solve it?
- Adds a new optional configuration to the experiment to enable preservation of the original cohorted users alternatives after a reset retain_user_alternatives_after_reset
- Updates references and usage of what would be the current version of the experiment to look at if the user is already assigned to the experiment previously to use their existing key/version.

### Test Plan

How to test: Load branch locally, and update themis gemfile to point to location of branch, rebuild your environment or rerun `rails c`

**Preserving originally cohorted users**
- [x] Configure an experiment with `retain_user_alternatives_after_reset: true`
- [x] Cohort a user into an experiment by calling` ab_test()
- [x] Confirm the alternative participants number has increased (in the dashboard)
- [x] Reset the experiment
- [x] Confirm the participant and completed numbers of the experiment are all 0
- [x] Call `ab_test()` again on the first user
- [x] Confirm the user continues to receive their assigned alternative (calling `ab_test()` and `ab_user.active_experiments` on the user still returns the same)
- [x] Confirm the cohorting and conversion numbers are unchanged
- [x] Call `ab_finished()` on the first user
- [x] Confirm the user continues to receive their assigned alternative (calling `ab_test()` and `user.active_experiments` on the user still returns the same)
- [x] Confirm the cohorting and conversion numbers are unchanged
- [x] Confirm the user has been given the finished key (calling `ab_user.keys`) matching the version of the experiment they were originally cohorted under
- [x] Cohort a new user into the experiment
- [x] Confirm the alternative participants number has increased
- [x] Call `ab_finished()`
- [x] Confirm the alternative completed number has increased
- [x] Confirm the user continues to receive their assigned alternative (calling `ab_test()` and `user.active_experiments` on the user still returns the same)
- [x] Confirm the user has been given the finished key (calling `ab_user.keys`) matching the version of the experiment they were originally cohorted under

**Supporting original behaviour (user will be reassigned once calling ab_test)**
- [x] Configure an experiment with `retain_user_alternatives_after_reset: false` OR do not specify the configuration at all
- [x] Cohort a user into an experiment by calling` ab_test()`
- [x] Confirm the alternative participants number has increased (in the dashboard)
- [x] call `user.keys` and take note of the redis keys
- [x] Reset the experiment
- [x] Confirm the participant and completed numbers of the experiment are all 0
- [x] Call `ab_test()` again on the first user
- [x] Confirm the alternative participants number has increased
- [x] Call `ab_finished()`
- [x] Confirm the alternative completed number has increased
- [x] call `user.keys` and take not the original keys are no longer there and the keys match the version number of the resetted experiment