### PR TITLE
Adds unregistered experiments to dashboard

### DIFF
--- a/lib/split/dashboard.rb
+++ b/lib/split/dashboard.rb
@@ -20,6 +20,7 @@ module Split
     get '/' do
       # Display experiments without a winner at the top of the dashboard
       @experiments = Split::ExperimentCatalog.all_active_first
+      @unintialized_experiments = Split.configuration.experiments.keys - @experiments.map(&:name)
 
       @metrics = Split::Metric.all
 
@@ -30,6 +31,11 @@ module Split
         @current_env = "Rack: #{Rack.version}"
       end
       erb :index
+    end
+
+    post '/initialize_experiment' do
+      Split::ExperimentCatalog.find_or_create(params[:experiment]) unless params[:experiment].nil? || params[:experiment].empty?
+      redirect url('/')
     end
 
     post '/force_alternative' do

--- a/lib/split/dashboard/public/style.css
+++ b/lib/split/dashboard/public/style.css
@@ -258,7 +258,7 @@ body {
   color: #408C48;
 }
 
-a.button, button, input[type="submit"] {
+.experiment a.button, .experiment button, .experiment input[type="submit"] {
   padding: 4px 10px;
   overflow: hidden;
   background: #d8dae0;
@@ -312,8 +312,12 @@ a.button.green:focus, button.green:focus, input[type="submit"].green:focus {
   background:#768E7A;
 }
 
-#filter, #clear-filter {
+.dashboard-controls input, .dashboard-controls select {
   padding: 10px;
+}
+
+.dashboard-controls-bottom {
+  margin-top: 10px;
 }
 
 

--- a/lib/split/dashboard/views/index.erb
+++ b/lib/split/dashboard/views/index.erb
@@ -1,10 +1,12 @@
 <% if @experiments.any? %>
   <p class="intro">The list below contains all the registered experiments along with the number of test participants, completed and conversion rate currently in the system.</p>
 
-  <input type="text" placeholder="Begin typing to filter" id="filter" />
-  <input type="button" id="toggle-completed" value="Hide completed" />
-  <input type="button" id="toggle-active" value="Hide active" />
-  <input type="button" id="clear-filter" value="Clear filters" />
+  <div class="dashboard-controls">
+    <input type="text" placeholder="Begin typing to filter" id="filter" />
+    <input type="button" id="toggle-completed" value="Hide completed" />
+    <input type="button" id="toggle-active" value="Hide active" />
+    <input type="button" id="clear-filter" value="Clear filters" />
+  </div>
 
   <% paginated(@experiments).each do |experiment| %>
     <% if experiment.goals.empty? %>
@@ -24,3 +26,16 @@
   <p class="intro">No experiments have started yet, you need to define them in your code and introduce them to your users.</p>
   <p class="intro">Check out the <a href='https://github.com/splitrb/split#readme'>Readme</a> for more help getting started.</p>
 <% end %>
+
+<div class="dashboard-controls dashboard-controls-bottom">
+  <form action="<%= url "/initialize_experiment" %>" method='post'>
+    <label>Add unregistered experiment: </label>
+    <select name="experiment" id="experiment-select">
+      <option selected disabled>experiment</option>
+      <% @unintialized_experiments.sort.each do |experiment_name| %>
+          <option value="<%= experiment_name %>"><%= experiment_name %></option>
+      <% end %>
+    </select>
+    <input type="submit" id="register-experiment-btn" value="register experiment"/>
+  </form>
+<div>

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -19,6 +19,7 @@ module Split
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
           user.delete Experiment.finished_key(key)
+          user.delete "#{key}:time_of_assignment"
         end
       end
       @cleaned_up = true

--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -183,6 +183,37 @@ describe Split::Dashboard do
     end
   end
 
+  describe "initialize experiment" do
+    before do 
+      Split.configuration.experiments = {
+        :my_experiment => {
+          :alternatives => [ "control", "alternative" ],
+        }
+      }
+    end
+
+    it "initializes the experiment when the experiment is given" do
+      expect(Split::ExperimentCatalog.find("my_experiment")).to be nil
+
+      post "/initialize_experiment", { experiment: "my_experiment"}
+
+      experiment = Split::ExperimentCatalog.find("my_experiment")
+      expect(experiment).to be_a(Split::Experiment)
+    end
+
+    it "does not attempt to intialize the experiment when empty experiment is given" do
+      post "/initialize_experiment", { experiment: ""}
+
+      expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+    end
+
+    it "does not attempt to intialize the experiment when no experiment is given" do
+      post "/initialize_experiment"
+
+      expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+    end
+  end
+
   it "should reset an experiment" do
     red_link.participant_count = 5
     blue_link.participant_count = 7


### PR DESCRIPTION
### What problem does this solve?
An experiment cannot be started unless ab_test is called so that the experiment is initialized.

### How does this solve it?
- Adds an endpoint to the dashboard to initialize a given experiment.
- Adds dropdown to dashboard view, populated with set difference of all experiments and already initialized experiments to invoke endpoint with.

![Screen Shot 2022-01-12 at 5 50 05 PM](https://user-images.githubusercontent.com/58270715/149251495-820324be-0fad-4244-beda-8f844b65967c.png)

### Test Plan

- [x] Download my [Split testing tool](https://github.com/robin-phung/split-rails-test) (we can't use manage to perform this test since it has a ported version of the dashboard)
- [x] Set split-rails-test gemfile to point to the downloaded path of split gem
- [x] Run `rails s`
- [x] Go to http://localhost:3000/split
- [x] Add an experiment to the board from the dropdown
- [x] Observe the added experiment is no longer in the dropdown
- [x] Remove the experiment from the board
- [x] Observe the removed experiment is back in the dropdown
