### PR TITLE
Return false when user does not have time of assignment and conversion window is enabled

### DIFF
--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -110,8 +110,11 @@ module Split
 
           return true if window_of_time_for_conversion_in_minutes.nil?
 
-          time_of_assignment = Time.parse(@user["#{user_experiment_key}:time_of_assignment"])
-          (Time.now - time_of_assignment)/60 <= window_of_time_for_conversion_in_minutes
+          time_of_assignment = @user["#{user_experiment_key}:time_of_assignment"]
+          
+          return false if time_of_assignment.nil? || time_of_assignment.empty?
+
+          (Time.now - Time.parse(time_of_assignment))/60 <= window_of_time_for_conversion_in_minutes
         end
       end
     end

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -426,6 +426,59 @@ describe Split::Trial do
     end
   end
 
+  describe "#within_conversion_time_frame?" do
+    let(:trial) { Split::Trial.new(:user => user, :experiment => experiment) }
+
+    it "memoizes the result" do
+      allow(Split.configuration).to receive(:experiments).and_return(experiment.name => { "window_of_time_for_conversion_in_minutes" => 60 })
+      trial.choose!
+
+      expect(Time).to receive(:parse).once.and_call_original
+
+      trial.within_conversion_time_frame?
+      trial.within_conversion_time_frame?
+    end
+
+    context "when window of time for conversion in minutes is configured" do
+      before do
+        allow(Split.configuration).to receive(:experiments).and_return(experiment.name => { "window_of_time_for_conversion_in_minutes" => 60 })
+        trial.choose!
+      end
+
+      it "returns false when user time of assignment is nil" do
+        user["#{experiment.key}:time_of_assignment"] = nil
+
+        expect(trial.within_conversion_time_frame?).to be_falsey
+      end
+
+      it "returns false when user time of assignment is empty" do
+        user["#{experiment.key}:time_of_assignment"] = ""
+
+        expect(trial.within_conversion_time_frame?).to be_falsey
+      end
+
+      it "returns false when user is not within the conversion time frame" do
+        allow(Time).to receive(:now).and_return(Time.now + 60*120)
+
+        expect(trial.within_conversion_time_frame?).to be_falsey
+      end
+
+      it "returns true when user is within the conversion time frame" do
+        expect(trial.within_conversion_time_frame?).to be_truthy
+      end
+    end
+
+    context "when window of time for conversion in minutes is not configured" do
+      before do
+        trial.choose!
+      end
+
+      it "returns true" do
+        expect(trial.within_conversion_time_frame?).to be_truthy
+      end
+    end
+  end
+
   describe "alternative recording" do
     before(:each) { Split.configuration.store_override = false }
 


### PR DESCRIPTION
### What problem does this solve?
When a user does not have the time_of_assignment key ab_finished will throw an exception. This can happen if a window_of_time_for_conversion_in_minutes is added after the experiment has started.

### How does this solve it?
- Checks if the key exists or is empty and return false
- Adds specs

### Test Plan (smoke testing conversion window)
- [x] Download my [Split testing tool](https://github.com/robin-phung/split-rails-test) (we can't use manage to perform this test since it has a ported version of the dashboard)
- [x] Download and checkout this branch of the split gem
- [x] Set split-rails-test gemfile to point to the downloaded path of your local split gem (ex: `gem 'split', path: "../../clio/split", require: 'split/dashboard'`)
- [x] Run `bundle install`
- [x] Run `rails s`
- [x] Go to split dashboard: http://localhost:3000/split
- [x] keep note of any already started experiments (if any) and the participant counts.
- [x] Engage with an experiment for a user and convert it (example:` http://localhost:3000/test/index?experiment=exp508&user=1&test=true` && `http://localhost:3000/test/index?experiment=exp508&user=1&finish=true`)
- [x] Check the split dashboard and confirm participants and completed increased by 1.
- [x] With a different user id engage with the experiment
- [x] Check the split dashboard and confirm participants increased by 1.
- [x] Wait passed a minute (the experiments are configured by default to have a window of 1 minute)
- [x] Convert the user for the experiment (this can be confirm by callback_finish indicating it was run on the test index page when finish is called as a param)
- [x]  Check the split dashboard and confirm completed **did not** increase by 1.

### Tips
If ruby is 3.0.1 is not installed, run: 
```
brew update && brew upgrade ruby-build
rbenv install 3.0.1
```

If redis is not installed, run:
```
brew install redis
brew tap homebrew/services
brew services start redis
```
