### PR TITLE
Update incorrect spec copy

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -377,7 +377,7 @@ describe Split::Helper do
           @experiment.increment_version
         end
 
-        it "increments the counter for the completed alternative" do
+        it "does not increment the counter for the completed alternative" do
           ab_finished(@experiment_name)
           new_completion_count = Split::Alternative.new(@alternative_name, @experiment_name).completed_count
           expect(new_completion_count).to eq(@previous_completion_count)


### PR DESCRIPTION
### What problem does this solve?
The spec copy is incorrect and stating the opposite of what its asserting.

### How does this solve it?
Updates the copy.