### PR TITLE
Add alternate copy for reset

### DIFF
--- a/lib/split/dashboard/public/dashboard.js
+++ b/lib/split/dashboard/public/dashboard.js
@@ -1,5 +1,9 @@
-function confirmReset() {
-  var agree = confirm("This will delete all data for this experiment?");
+function confirmReset(retain_user_alternatives_after_reset) {
+  warning_message = retain_user_alternatives_after_reset
+    ? "This will reset the data for this experiment. Existing users will retain their assigned alternative while not impacting new version metrics. Are you Sure?"
+    : "This will delete all data for this experiment. Existing users may be recohorted into a new alternative. Are you sure?";
+
+  var agree = confirm(warning_message);
   return agree ? true : false;
 }
 

--- a/lib/split/dashboard/views/_controls.erb
+++ b/lib/split/dashboard/views/_controls.erb
@@ -17,7 +17,7 @@
 <% end %>
 <span class="divider">|</span>
 <% if experiment.start_time %>
-  <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset()">
+  <form action="<%= url "/reset?experiment=#{experiment.name}" %>" method='post' onclick="return confirmReset(<%= experiment.retain_user_alternatives_after_reset %>)">
     <input type="submit" value="Reset Data">
   </form>
 <% else%>


### PR DESCRIPTION
### What problem does this solve?
With the recent addition to preserve existing cohorted users in the experiment after a reset. This creates 2 different behaviours when a reset occurs. 

### How does this solve it?
Adds conditional copy to the dashboard depending on if `retain_user_alternatives_after_reset` is enabled/disabled.

### Test Plan
- [x] Download my [Split testing tool](https://github.com/robin-phung/split-rails-test) (we can't use manage to perform this test since it has a ported version of the dashboard)
- [x] Download and checkout this branch of the split gem
- [x] Set split-rails-test gemfile to point to the downloaded path of your local split gem (ex: `gem 'split', path: "../../clio/split", require: 'split/dashboard'`)
- [x] Go to the experiments yaml and update any of the experiments to include: `retain_user_alternatives_after_reset: true`
- [x] Run `bundle install`
- [x] Run `rails s`
- [x] Go to http://localhost:3000/split
- [x] Add the experiment that was modified to the board from the dropdown and start it
- [x] Click reset and observe the dialog message containing: **_This will reset the data for this experiment. Existing users will retain their assigned alternative while not impacting new version metrics. Are you Sure?_**
- [x] Add another experiment to the board from the dropdown and start it
- [x] Click reset and observe the dialog message containing: _**This will delete all data for this experiment. Existing users may be recohorted into a new alternative. Are you sure?**_

@clio/product-growth 