### PR TITLE
Fix incorrect ordering of expect in dashboard spec

### DIFF
--- a/spec/dashboard_spec.rb
+++ b/spec/dashboard_spec.rb
@@ -202,15 +202,15 @@ describe Split::Dashboard do
     end
 
     it "does not attempt to intialize the experiment when empty experiment is given" do
-      post "/initialize_experiment", { experiment: ""}
-
       expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+
+      post "/initialize_experiment", { experiment: ""}
     end
 
     it "does not attempt to intialize the experiment when no experiment is given" do
-      post "/initialize_experiment"
-
       expect(Split::ExperimentCatalog).to_not receive(:find_or_create)
+
+      post "/initialize_experiment"
     end
   end
 


### PR DESCRIPTION
### What problem does this solve?
The spec is incorrectly spying after the call was made returning a false positive.

### How does this solve it?
Reorders the expect before the call.

@clio/product-growth 