### PR TITLE
Fix erroneous capitalization in reset button message

### DIFF
--- a/lib/split/dashboard/public/dashboard.js
+++ b/lib/split/dashboard/public/dashboard.js
@@ -1,6 +1,6 @@
 function confirmReset(retain_user_alternatives_after_reset) {
   warning_message = retain_user_alternatives_after_reset
-    ? "This will reset the data for this experiment. Existing users will retain their assigned alternative while not impacting new version metrics. Are you Sure?"
+    ? "This will reset the data for this experiment. Existing users will retain their assigned alternative while not impacting new version metrics. Are you sure?"
     : "This will delete all data for this experiment. Existing users may be recohorted into a new alternative. Are you sure?";
 
   var agree = confirm(warning_message);


### PR DESCRIPTION
### What problem does this solve?
"Sure" was accidentally capitalized... oof...

### How does this solve it?
makes sure "sure" lower case

### Test Plan
- [x] Download my [Split testing tool](https://github.com/robin-phung/split-rails-test) (we can't use manage to perform this test since it has a ported version of the dashboard)
- [x] Download and checkout this branch of the split gem
- [x] Set split-rails-test gemfile to point to the downloaded path of your local split gem (ex: `gem 'split', path: "../../clio/split", require: 'split/dashboard'`)
- [x] Go to the experiments yaml and update any of the experiments to include: `retain_user_alternatives_after_reset: true`
- [x] Run `bundle install`
- [x] Run `rails s`
- [x] Go to http://localhost:3000/split
- [x] Add the experiment that was modified to the board from the dropdown and start it
- [x] Click reset and observe the dialog message containing: **_This will reset the data for this experiment. Existing users will retain their assigned alternative while not impacting new version metrics. Are you sure?_**
- [x] Add another experiment to the board from the dropdown and start it
- [x] Click reset and observe the dialog message containing: _**This will delete all data for this experiment. Existing users may be recohorted into a new alternative. Are you sure?**_

### Tips
If ruby is 3.0.1 is not installed, run: 
```
brew update && brew upgrade ruby-build
rbenv install 3.0.1
```

If redis is not installed, run:
```
brew install redis
brew tap homebrew/services
brew services start redis
```