### PR TITLE
Update user.rb's experiment keys related calculation

### DIFF
--- a/CLIO_CHANGE_LOG.md
+++ b/CLIO_CHANGE_LOG.md
@@ -1,0 +1,6 @@
+1. Added a new field `time_of_assignment` in Redis, and use it to calculate if the user is within the conversion time frame.
+2. Added a new field `retain_user_alternatives_after_reset` in YML file, and use it to keep the user's alternative after
+the experiment is reset.
+3. Updated the `user.rb`'s calculation about `keys_without_experiment` and renamed `keys_without_finished` to 
+`experiment_keys`. Because we have our own fields in the Redis, like `time_of_assignment` and `eligibility`, we need to 
+exclude them from those functions, in case it breaks Split's behaviour.

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -14,7 +14,7 @@ module Split
 
     def cleanup_old_experiments!
       return if @cleaned_up
-      keys_without_finished_and_time_of_assignment(user.keys).each do |key|
+      experiment_keys(user.keys).each do |key|
         experiment = ExperimentCatalog.find key_without_version(key)
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
@@ -38,13 +38,13 @@ module Split
     end
 
     def cleanup_old_versions!(experiment)
-      keys = user.keys.select { |k| k.match(Regexp.new(experiment.name)) }
+      keys = user.keys.select { |k| k.match(Regexp.new("^#{experiment.name}(:|$)")) }
       keys_without_experiment(keys, experiment.key).each { |key| user.delete(key) }
     end
 
     def active_experiments
       experiment_pairs = {}
-      keys_without_finished_and_time_of_assignment(user.keys).each do |key|
+      experiment_keys(user.keys).each do |key|
         Metric.possible_experiments(key_without_version(key)).each do |experiment|
           if !experiment.has_winner?
             experiment_pairs[key_without_version(key)] = user[key]
@@ -83,11 +83,30 @@ module Split
     private
 
     def keys_without_experiment(keys, experiment_key)
-      keys.reject { |k| k.match(Regexp.new("^#{experiment_key}(:finished)?$")) || k.match("#{experiment_key}:time_of_assignment") }
+      if experiment_key.include?(':')
+        sub_keys = keys.reject { |k| k.match(Regexp.new("^#{experiment_key}$")) }
+        sub_keys.reject do |k|
+          if k.match(Regexp.new("^#{experiment_key}:"))
+            sub_str = k.partition(':').last
+            sub_str.scan(Regexp.new("\\D")).any?
+          else
+            false
+          end
+        end
+      else
+       keys.select do |k|
+          k.match(Regexp.new("^#{experiment_key}:\\d+:")) ||
+            k.match(Regexp.new("^#{experiment_key}:\\d+$")) ||
+            k.match(Regexp.new("^#{experiment_key}[^:]+"))
+        end
+      end
     end
 
-    def keys_without_finished_and_time_of_assignment(keys)
-      keys.reject { |k| k.include?(":finished") || k.include?(":time_of_assignment") }
+    def experiment_keys(keys)
+      keys.reject do |k|
+        sub_str = k.partition(':').last
+        sub_str.scan(Regexp.new("\\D")).any?
+      end
     end
 
     def key_without_version(key)

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -95,8 +95,7 @@ module Split
         end
       else
         keys.select do |k|
-          k.match(Regexp.new("^#{experiment_key}:\\d+:")) ||
-            k.match(Regexp.new("^#{experiment_key}:\\d+$")) ||
+          k.match(Regexp.new("^#{experiment_key}:\\d+(:|$)")) ||
             k.partition(':').first != experiment_key
         end
       end

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -84,7 +84,7 @@ module Split
 
     def keys_without_experiment(keys, experiment_key)
       if experiment_key.include?(':')
-        sub_keys = keys.reject { |k| k.match(Regexp.new("^#{experiment_key}$")) }
+        sub_keys = keys.reject { |k| k == experiment_key }
         sub_keys.reject do |k|
           if k.match(Regexp.new("^#{experiment_key}:"))
             sub_str = k.partition(':').last

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -86,12 +86,9 @@ module Split
       if experiment_key.include?(':')
         sub_keys = keys.reject { |k| k == experiment_key }
         sub_keys.reject do |k|
-          if k.match(Regexp.new("^#{experiment_key}:"))
-            sub_str = k.partition(':').last
-            sub_str.scan(Regexp.new("\\D")).any?
-          else
-            false
-          end
+          sub_str = k.partition(':').last
+
+          k.match(Regexp.new("^#{experiment_key}:")) && sub_str.scan(Regexp.new("\\D")).any?
         end
       else
         keys.select do |k|

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -94,10 +94,10 @@ module Split
           end
         end
       else
-       keys.select do |k|
+        keys.select do |k|
           k.match(Regexp.new("^#{experiment_key}:\\d+:")) ||
             k.match(Regexp.new("^#{experiment_key}:\\d+$")) ||
-            k.match(Regexp.new("^#{experiment_key}[^:]+"))
+            k.partition(':').first != experiment_key
         end
       end
     end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -238,14 +238,6 @@ describe Split::User do
         it "max reached when checking against another experiment contain current experiment as substring" do
           expect(@subject.max_experiments_reached?("link_color_v2")).to be_truthy
         end
-
-        it "max not reached when checking against same experiment" do
-          expect(@subject.max_experiments_reached?("link_color")).to be_falsey
-        end
-
-        it "max reached when checking against same experiment but different version" do
-          expect(@subject.max_experiments_reached?("link_color:1")).to be_truthy
-        end
       end
 
       context "when user is already in an experiment with version number" do
@@ -273,18 +265,6 @@ describe Split::User do
         it "max reached when checking against another experiment contain current experiment as substring, but same version" do
           expect(@subject.max_experiments_reached?("link_color_v2:2")).to be_truthy
         end
-
-        it "max reached when checking against same experiment but without version" do
-          expect(@subject.max_experiments_reached?("link_color")).to be_truthy
-        end
-
-        it "max not reached when checking against same experiment" do
-          expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
-        end
-
-        it "max reached when checking against same experiment but another version" do
-          expect(@subject.max_experiments_reached?("link_color:2")).to be_truthy
-        end
       end
     end
 
@@ -301,12 +281,12 @@ describe Split::User do
       context "user is not in any experiments" do
         let(:user_keys) { { } }
 
-        it "max not reached for experiment1" do
+        it "max not reached for experiment" do
           expect(@subject.max_experiments_reached?("link_color")).to be_falsey
         end
 
-        it "max not reached for experiment2 with a different version" do
-          expect(@subject.max_experiments_reached?("link_shape:2")).to be_falsey
+        it "max not reached for experiment with a version" do
+          expect(@subject.max_experiments_reached?("link_color:2")).to be_falsey
         end
       end
 
@@ -320,12 +300,8 @@ describe Split::User do
           }
         end
 
-        it "max not reached for experiment1" do
+        it "max not reached for a different experiment" do
           expect(@subject.max_experiments_reached?("link_color")).to be_falsey
-        end
-
-        it "max not reached for experiment2 with a different version" do
-          expect(@subject.max_experiments_reached?("link_shape:2")).to be_falsey
         end
       end
 
@@ -343,14 +319,6 @@ describe Split::User do
           }
         end
 
-        it "max not reached for experiment1" do
-          expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
-        end
-
-        it "max reached for experiment2" do
-          expect(@subject.max_experiments_reached?("link_shape:1")).to be_truthy
-        end
-
         it "max reached for other experiments" do
           expect(@subject.max_experiments_reached?("link_font")).to be_truthy
         end
@@ -360,23 +328,27 @@ describe Split::User do
     context "when multiple experiments are allowed" do
       let(:alternatives) { [ "control", "blue" ] }
       let(:experiment2) { Split::Experiment.new('link_shape') }
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color:eligibility' => "ELIGIBLE",
+          'link_shape' => 'blue',
+          'link_shape:finished' => true,
+          'link_shape:time_of_assignment' => Time.now.to_s,
+          'link_shape:eligibility' => "ELIGIBLE",
+        }
+      end
 
       before do
-        Split.configuration.allow_multiple_experiments = "control"
+        Split.configuration.allow_multiple_experiments = "true"
         Split::ExperimentCatalog.find_or_create("link_color", alternatives)
         Split::ExperimentCatalog.find_or_create("link_shape", alternatives)
       end
 
-      it "max not reached for experiment1" do
-        expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
-      end
-
-      it "max reached for experiment2" do
-        expect(@subject.max_experiments_reached?("link_shape:1")).to be_truthy
-      end
-
-      it "max reached for other experiments" do
-        expect(@subject.max_experiments_reached?("link_font")).to be_truthy
+      it "max not reached for other experiments" do
+        expect(@subject.max_experiments_reached?("link_font")).to be_falsey
       end
     end
   end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -16,12 +16,113 @@ describe Split::User do
     expect(@subject['link_color']).to eq(@subject.user['link_color'])
   end
 
-  context '#cleanup_old_versions!' do
-    let(:user_keys) { { 'link_color:1' => 'blue' } }
+  describe '#cleanup_old_versions!' do
+    context 'current version does not have number' do
+      describe 'cleans the experiments with versions' do
+        let(:user_keys) { { 'link_color:1' => 'blue', 'link_color:1:finished' => 'true' } }
 
-    it 'removes key if old experiment is found' do
-      @subject.cleanup_old_versions!(experiment)
-      expect(@subject.keys).to be_empty
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'does not clean its own experiment' do
+        let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment' do
+        let(:user_keys) { { 'link' => 'a:b', 'link:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment with version' do
+        let(:user_keys) { { 'link:1' => 'a:b', 'link:1:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment having the experiment as substring' do
+        let(:user_keys) { { 'link_color2' => 'blue', 'link_color2:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment having the experiment as substring' do
+        let(:user_keys) { { 'link_color2:1' => 'blue', 'link_color2:1:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+    end
+
+    context 'current version has number' do
+      before do
+        experiment.reset
+        experiment.reset
+      end
+
+      describe 'cleans the experiments without version' do
+        let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'cleans the experiments with previous version' do
+        let(:user_keys) { { 'link_color:1' => 'blue', 'link_color:1:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'does not clean its own experiment' do
+        let(:user_keys) { { 'link_color:2' => 'blue', 'link_color:2:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment having the experiment as substring' do
+        let(:user_keys) { { 'link_color2' => 'blue', 'link_color2:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'does not clean other experiment having the experiment as substring' do
+        let(:user_keys) { { 'link_color2:2' => 'blue', 'link_color2:2:finished' => 'true' } }
+
+        it 'removes key if old experiment is found' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
     end
   end 
 
@@ -72,7 +173,7 @@ describe Split::User do
       end
 
       it 'does not clean up again' do
-        expect(@subject).to_not receive(:keys_without_finished_and_time_of_assignment)
+        expect(@subject).to_not receive(:experiment_keys)
         @subject.cleanup_old_experiments!
       end
     end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -127,11 +127,13 @@ describe Split::User do
   end 
 
   context '#cleanup_old_experiments!' do
-    let(:user_keys) { {
-      'link_color' => 'blue',
-      'link_color:finished' => true,
-      'link_color:time_of_assignment' => Time.now.to_s,
-    } }
+    let(:user_keys) do
+      {
+        'link_color' => 'blue',
+        'link_color:finished' => true,
+        'link_color:time_of_assignment' => Time.now.to_s,
+      }
+    end
 
     it 'removes keys if experiment is not found' do
       @subject.cleanup_old_experiments!
@@ -172,13 +174,15 @@ describe Split::User do
     end
 
     describe "when the user is in the experiment with version number" do
-      let(:user_keys) { {
-        'link_color:1' => 'blue',
-        'link_color:1:finished' => true,
-        'link_color:1:time_of_assignment' => Time.now.to_s,
-      } }
+      let(:user_keys) do
+        {
+          'link_color:1' => 'blue',
+          'link_color:1:finished' => true,
+          'link_color:1:time_of_assignment' => Time.now.to_s,
+        }
+      end
 
-      it 'keeps keys if the experiment has no winner and has started' do
+      it 'keeps keys when the experiment has no winner and has started' do
         allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
         allow(experiment).to receive(:has_winner?).and_return(false)
         allow(experiment).to receive(:start_time).and_return(Date.today)
@@ -210,8 +214,7 @@ describe Split::User do
       end
 
       context "when user is not in any experiment" do
-        let(:user_keys) { {
-        } }
+        let(:user_keys) { { } }
 
         it "max not reached when checking against same experiment" do
           expect(@subject.max_experiments_reached?("link_color")).to be_falsey
@@ -219,12 +222,14 @@ describe Split::User do
       end
 
       context "when user is already in an experiment" do
-        let(:user_keys) { {
-          'link_color' => 'blue',
-          'link_color:finished' => true,
-          'link_color:time_of_assignment' => Time.now.to_s,
-          'link_color:eligibility' => "ELIGIBLE",
-        } }
+        let(:user_keys) do
+          {
+            'link_color' => 'blue',
+            'link_color:finished' => true,
+            'link_color:time_of_assignment' => Time.now.to_s,
+            'link_color:eligibility' => "ELIGIBLE",
+          }
+        end
 
         it "max reached when checking against another experiment" do
           expect(@subject.max_experiments_reached?("link")).to be_truthy
@@ -244,12 +249,14 @@ describe Split::User do
       end
 
       context "when user is already in an experiment with version number" do
-        let(:user_keys) { {
-          'link_color:1' => 'blue',
-          'link_color:1:finished' => true,
-          'link_color:1:time_of_assignment' => Time.now.to_s,
-          'link_color:1:eligibility' => "ELIGIBLE",
-        } }
+        let(:user_keys) do
+          {
+            'link_color:1' => 'blue',
+            'link_color:1:finished' => true,
+            'link_color:1:time_of_assignment' => Time.now.to_s,
+            'link_color:1:eligibility' => "ELIGIBLE",
+          }
+        end
 
         it "max reached when checking against another experiment" do
           expect(@subject.max_experiments_reached?("link")).to be_truthy
@@ -267,7 +274,7 @@ describe Split::User do
           expect(@subject.max_experiments_reached?("link_color_v2:2")).to be_truthy
         end
 
-        it "max not reached when checking against same experiment but without version" do
+        it "max reached when checking against same experiment but without version" do
           expect(@subject.max_experiments_reached?("link_color")).to be_truthy
         end
 
@@ -275,7 +282,7 @@ describe Split::User do
           expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
         end
 
-        it "max not reached when checking against same experiment but another version" do
+        it "max reached when checking against same experiment but another version" do
           expect(@subject.max_experiments_reached?("link_color:2")).to be_truthy
         end
       end
@@ -292,8 +299,7 @@ describe Split::User do
       end
 
       context "user is not in any experiments" do
-        let(:user_keys) { {
-        } }
+        let(:user_keys) { { } }
 
         it "max not reached for experiment1" do
           expect(@subject.max_experiments_reached?("link_color")).to be_falsey
@@ -305,12 +311,14 @@ describe Split::User do
       end
 
       context "user is in control with experiment2" do
-        let(:user_keys) { {
-          'link_shape' => 'control',
-          'link_shape:finished' => true,
-          'link_shape:time_of_assignment' => Time.now.to_s,
-          'link_shape:eligibility' => "ELIGIBLE",
-        } }
+        let(:user_keys) do
+          {
+            'link_shape' => 'control',
+            'link_shape:finished' => true,
+            'link_shape:time_of_assignment' => Time.now.to_s,
+            'link_shape:eligibility' => "ELIGIBLE",
+          }
+        end
 
         it "max not reached for experiment1" do
           expect(@subject.max_experiments_reached?("link_color")).to be_falsey
@@ -322,16 +330,18 @@ describe Split::User do
       end
 
       context "user is in alternative with experiment1, control with experiment2" do
-        let(:user_keys) { {
-          'link_color' => 'blue',
-          'link_color:finished' => true,
-          'link_color:time_of_assignment' => Time.now.to_s,
-          'link_color:eligibility' => "ELIGIBLE",
-          'link_shape' => 'control',
-          'link_shape:finished' => true,
-          'link_shape:time_of_assignment' => Time.now.to_s,
-          'link_shape:eligibility' => "ELIGIBLE",
-        } }
+        let(:user_keys) do
+          {
+            'link_color' => 'blue',
+            'link_color:finished' => true,
+            'link_color:time_of_assignment' => Time.now.to_s,
+            'link_color:eligibility' => "ELIGIBLE",
+            'link_shape' => 'control',
+            'link_shape:finished' => true,
+            'link_shape:time_of_assignment' => Time.now.to_s,
+            'link_shape:eligibility' => "ELIGIBLE",
+          }
+        end
 
         it "max not reached for experiment1" do
           expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
@@ -352,7 +362,6 @@ describe Split::User do
       let(:experiment2) { Split::Experiment.new('link_shape') }
 
       before do
-        Split.configuration.allow_multiple_experiments = true
         Split.configuration.allow_multiple_experiments = "control"
         Split::ExperimentCatalog.find_or_create("link_color", alternatives)
         Split::ExperimentCatalog.find_or_create("link_shape", alternatives)
@@ -362,11 +371,11 @@ describe Split::User do
         expect(@subject.max_experiments_reached?("link_color:1")).to be_falsey
       end
 
-      it "max not reached for experiment2" do
+      it "max reached for experiment2" do
         expect(@subject.max_experiments_reached?("link_shape:1")).to be_truthy
       end
 
-      it "max not reached for other experiments" do
+      it "max reached for other experiments" do
         expect(@subject.max_experiments_reached?("link_font")).to be_truthy
       end
     end
@@ -374,12 +383,14 @@ describe Split::User do
 
   context "#active_experiments" do
     context "when the experiment has no version number" do
-      let(:user_keys) { {
-        'link_color' => 'blue',
-        'link_color:finished' => true,
-        'link_color:time_of_assignment' => Time.now.to_s,
-        'link_color:eligibility' => "ELIGIBLE",
-      } }
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color:eligibility' => "ELIGIBLE",
+        }
+      end
 
       context "when the experiment no longer exists" do
         it "doesn't include the experiment" do
@@ -407,12 +418,14 @@ describe Split::User do
     end
 
     context "when the experiment has a version number" do
-      let(:user_keys) { {
-        'link_color:1' => 'blue',
-        'link_color:1:finished' => true,
-        'link_color:1:time_of_assignment' => Time.now.to_s,
-        'link_color:1:eligibility' => "ELIGIBLE",
-      } }
+      let(:user_keys) do
+        {
+          'link_color:1' => 'blue',
+          'link_color:1:finished' => true,
+          'link_color:1:time_of_assignment' => Time.now.to_s,
+          'link_color:1:eligibility' => "ELIGIBLE",
+        }
+      end
       before do
         experiment.reset
       end


### PR DESCRIPTION
fixes https://github.com/clio/themis/issues/88898
### What problem does this solve?
We have our own keys other than `finished` saved in Redis, like `eligibility` or `time_of_assignment`. Split only treats the `exp`, `exp:2`, or `exp:finished` as the experiment context. To avoid these keys influencing Split's behaviour, and to avoid building up the list of the experiment context, we should find all the experiment contexts by the pattern. Otherwise, the function like `keys_without_experiment` won't be about to filter out `eligibility` or `time_of_assignment` for an experiment. 

### How does this solve it?
Update the calculation of `keys_without_experiment` and `experiment_keys`