### PR TITLE
Fix tests for experiment

### DIFF
--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -480,13 +480,13 @@ describe Split::Experiment do
 
   describe "#disable_cohorting" do
     it "saves a new key in redis" do
-      expect(experiment.disable_cohorting).to eq true
+      expect(experiment.disable_cohorting).to eq 1
     end
   end
 
   describe "#enable_cohorting" do
     it "saves a new key in redis" do
-      expect(experiment.enable_cohorting).to eq true
+      expect(experiment.enable_cohorting).to eq 1
     end
   end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -478,18 +478,6 @@ describe Split::Experiment do
     end
   end
 
-  describe "#disable_cohorting" do
-    it "saves a new key in redis" do
-      expect(experiment.disable_cohorting).to eq 1
-    end
-  end
-
-  describe "#enable_cohorting" do
-    it "saves a new key in redis" do
-      expect(experiment.enable_cohorting).to eq 1
-    end
-  end
-
   describe 'changing an existing experiment' do
     def same_but_different_alternative
       Split::ExperimentCatalog.find_or_create('link_color', 'blue', 'yellow', 'orange')


### PR DESCRIPTION
### What problem does this solve?
Tests failed because `experiment.disable_cohorting`/ `experiment.enable_cohorting` returns the number of fields added instead of boolean.

### How does this solve it?
The implementation of those two methods is `redis.hset`. Based on Redis, the return of it is: 
[Integer reply](https://redis.io/docs/reference/protocol-spec#resp-integers): The number of fields that were added.

Because the latest split no longer has these two tests, I decided to remove these two tests, to keep consistency as Split repo.