### PR TITLE
Update user.rb's experiment keys related calculation

### DIFF
--- a/CLIO_CHANGE_LOG.md
+++ b/CLIO_CHANGE_LOG.md
@@ -1,0 +1,6 @@
+1. Added a new field `time_of_assignment` in Redis, and use it to calculate if the user is within the conversion time frame.
+2. Added a new field `retain_user_alternatives_after_reset` in YML file, and use it to keep the user's alternative after
+the experiment is reset.
+3. Updated the `user.rb`'s calculation about `keys_without_experiment` and renamed `keys_without_finished` to 
+`experiment_keys`. Because we have our own fields in the Redis, like `time_of_assignment` and `eligibility`, we need to 
+exclude them from those functions, in case it breaks Split's behaviour.

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -16,21 +16,128 @@ describe Split::User do
     expect(@subject['link_color']).to eq(@subject.user['link_color'])
   end
 
-  context '#cleanup_old_versions!' do
-    let(:user_keys) { { 'link_color:1' => 'blue' } }
+  describe '#cleanup_old_versions!' do
+    context 'current version does not have number' do
+      describe 'when the user is in the experiment with old version number' do
+        let(:user_keys) { { 'link_color:1' => 'blue', 'link_color:1:finished' => 'true' } }
 
-    it 'removes key if old experiment is found' do
-      @subject.cleanup_old_versions!(experiment)
-      expect(@subject.keys).to be_empty
+        it 'removes all the old version keys' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'when the user is in the experiment with current version' do
+        let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is in another experiment without version number' do
+        let(:user_keys) { { 'link' => 'a:b', 'link:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is in another experiment with version number' do
+        let(:user_keys) { { 'link:1' => 'a:b', 'link:1:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is in another experiment having the current experiment name as substring' do
+        let(:user_keys) { { 'link_color2' => 'blue', 'link_color2:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is another experiment with version, having the current experiment name as substring ' do
+        let(:user_keys) { { 'link_color2:1' => 'blue', 'link_color2:1:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+    end
+
+    context 'current version has number' do
+      before do
+        experiment.reset
+        experiment.reset
+      end
+
+      describe 'when the user is in the experiment without version number' do
+        let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => 'true' } }
+
+        it 'removes all the old version keys' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'when the user is in the experiment with an old version number' do
+        let(:user_keys) { { 'link_color:1' => 'blue', 'link_color:1:finished' => 'true' } }
+
+        it 'removes all the old version keys' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys).to be_empty
+        end
+      end
+
+      describe 'when the user is in the experiment with current version number' do
+        let(:user_keys) { { 'link_color:2' => 'blue', 'link_color:2:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is in another experiment, having the current experiment name as substring' do
+        let(:user_keys) { { 'link_color2' => 'blue', 'link_color2:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
+
+      describe 'when the user is in another experiment with version, having the current experiment name as substring' do
+        let(:user_keys) { { 'link_color2:2' => 'blue', 'link_color2:2:finished' => 'true' } }
+
+        it 'all the keys are reserved' do
+          @subject.cleanup_old_versions!(experiment)
+          expect(@subject.keys.size).to be(2)
+        end
+      end
     end
   end 
 
   context '#cleanup_old_experiments!' do
-    let(:user_keys) { { 'link_color' => 'blue', 'link_color:finished' => true, 'link_color:time_of_assignment' => Time.now.to_s } }
+    let(:user_keys) do
+      {
+        'link_color' => 'blue',
+        'link_color:finished' => true,
+        'link_color:time_of_assignment' => Time.now.to_s,
+      }
+    end
 
     it 'removes keys if experiment is not found' do
       @subject.cleanup_old_experiments!
-      
+
       expect(@subject.keys).to be_empty
     end
 
@@ -66,14 +173,257 @@ describe Split::User do
       expect(@subject.keys).to include("link_color:time_of_assignment")
     end
 
+    describe "when the user is in the experiment with version number" do
+      let(:user_keys) do
+        {
+          'link_color:1' => 'blue',
+          'link_color:1:finished' => true,
+          'link_color:1:time_of_assignment' => Time.now.to_s,
+        }
+      end
+
+      it 'keeps keys when the experiment has no winner and has started' do
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        allow(experiment).to receive(:has_winner?).and_return(false)
+        allow(experiment).to receive(:start_time).and_return(Date.today)
+
+        @subject.cleanup_old_experiments!
+
+        expect(@subject.keys).to include("link_color:1")
+        expect(@subject.keys).to include("link_color:1:finished")
+        expect(@subject.keys).to include("link_color:1:time_of_assignment")
+      end
+    end
+
     context 'when already cleaned up' do
       before do
         @subject.cleanup_old_experiments!
       end
 
       it 'does not clean up again' do
-        expect(@subject).to_not receive(:keys_without_finished_and_time_of_assignment)
+        expect(@subject).to_not receive(:experiment_keys)
         @subject.cleanup_old_experiments!
+      end
+    end
+  end
+
+  context "#max_experiments_reached?" do
+    context "when multiple experiments are not allowed" do
+      before do
+        Split.configuration.allow_multiple_experiments = false
+      end
+
+      context "when user is not in any experiment" do
+        let(:user_keys) { { } }
+
+        it "max not reached when checking against same experiment" do
+          expect(@subject.max_experiments_reached?("link_color")).to be_falsey
+        end
+      end
+
+      context "when user is already in an experiment" do
+        let(:user_keys) do
+          {
+            'link_color' => 'blue',
+            'link_color:finished' => true,
+            'link_color:time_of_assignment' => Time.now.to_s,
+            'link_color:eligibility' => "ELIGIBLE",
+          }
+        end
+
+        it "max reached when checking against another experiment" do
+          expect(@subject.max_experiments_reached?("link")).to be_truthy
+        end
+
+        it "max reached when checking against another experiment contain current experiment as substring" do
+          expect(@subject.max_experiments_reached?("link_color_v2")).to be_truthy
+        end
+      end
+
+      context "when user is already in an experiment with version number" do
+        let(:user_keys) do
+          {
+            'link_color:1' => 'blue',
+            'link_color:1:finished' => true,
+            'link_color:1:time_of_assignment' => Time.now.to_s,
+            'link_color:1:eligibility' => "ELIGIBLE",
+          }
+        end
+
+        it "max reached when checking against another experiment" do
+          expect(@subject.max_experiments_reached?("link")).to be_truthy
+        end
+
+        it "max reached when checking against another experiment but same version" do
+          expect(@subject.max_experiments_reached?("link:2")).to be_truthy
+        end
+
+        it "max reached when checking against another experiment contain current experiment as substring" do
+          expect(@subject.max_experiments_reached?("link_color_v2")).to be_truthy
+        end
+
+        it "max reached when checking against another experiment contain current experiment as substring, but same version" do
+          expect(@subject.max_experiments_reached?("link_color_v2:2")).to be_truthy
+        end
+      end
+    end
+
+    context "when multiple experiments with control are allowed" do
+      let(:alternatives) { [ "control", "blue" ] }
+      let(:experiment2) { Split::Experiment.new('link_shape') }
+
+      before do
+        Split.configuration.allow_multiple_experiments = "control"
+        Split::ExperimentCatalog.find_or_create("link_color", alternatives)
+        Split::ExperimentCatalog.find_or_create("link_shape", alternatives)
+      end
+
+      context "user is not in any experiments" do
+        let(:user_keys) { { } }
+
+        it "max not reached for experiment" do
+          expect(@subject.max_experiments_reached?("link_color")).to be_falsey
+        end
+
+        it "max not reached for experiment with a version" do
+          expect(@subject.max_experiments_reached?("link_color:2")).to be_falsey
+        end
+      end
+
+      context "user is in control with experiment2" do
+        let(:user_keys) do
+          {
+            'link_shape' => 'control',
+            'link_shape:finished' => true,
+            'link_shape:time_of_assignment' => Time.now.to_s,
+            'link_shape:eligibility' => "ELIGIBLE",
+          }
+        end
+
+        it "max not reached for a different experiment" do
+          expect(@subject.max_experiments_reached?("link_color")).to be_falsey
+        end
+      end
+
+      context "user is in alternative with experiment1, control with experiment2" do
+        let(:user_keys) do
+          {
+            'link_color' => 'blue',
+            'link_color:finished' => true,
+            'link_color:time_of_assignment' => Time.now.to_s,
+            'link_color:eligibility' => "ELIGIBLE",
+            'link_shape' => 'control',
+            'link_shape:finished' => true,
+            'link_shape:time_of_assignment' => Time.now.to_s,
+            'link_shape:eligibility' => "ELIGIBLE",
+          }
+        end
+
+        it "max reached for other experiments" do
+          expect(@subject.max_experiments_reached?("link_font")).to be_truthy
+        end
+      end
+    end
+
+    context "when multiple experiments are allowed" do
+      let(:alternatives) { [ "control", "blue" ] }
+      let(:experiment2) { Split::Experiment.new('link_shape') }
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color:eligibility' => "ELIGIBLE",
+          'link_shape' => 'blue',
+          'link_shape:finished' => true,
+          'link_shape:time_of_assignment' => Time.now.to_s,
+          'link_shape:eligibility' => "ELIGIBLE",
+        }
+      end
+
+      before do
+        Split.configuration.allow_multiple_experiments = "true"
+        Split::ExperimentCatalog.find_or_create("link_color", alternatives)
+        Split::ExperimentCatalog.find_or_create("link_shape", alternatives)
+      end
+
+      it "max not reached for other experiments" do
+        expect(@subject.max_experiments_reached?("link_font")).to be_falsey
+      end
+    end
+  end
+
+  context "#active_experiments" do
+    context "when the experiment has no version number" do
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color:eligibility' => "ELIGIBLE",
+        }
+      end
+
+      context "when the experiment no longer exists" do
+        it "doesn't include the experiment" do
+          expect(@subject.active_experiments).to be_empty
+        end
+      end
+
+      context "when the experiment exists" do
+        before do
+          allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        end
+
+        it "only includes the experiment when there is no winner" do
+          allow(experiment).to receive(:has_winner?).and_return(false)
+
+          expect(@subject.active_experiments).to eq({'link_color' => 'blue'})
+        end
+
+        it "doesn't include the experiment when there is a winner" do
+          allow(experiment).to receive(:has_winner?).and_return(true)
+
+          expect(@subject.active_experiments).to be_empty
+        end
+      end
+    end
+
+    context "when the experiment has a version number" do
+      let(:user_keys) do
+        {
+          'link_color:1' => 'blue',
+          'link_color:1:finished' => true,
+          'link_color:1:time_of_assignment' => Time.now.to_s,
+          'link_color:1:eligibility' => "ELIGIBLE",
+        }
+      end
+      before do
+        experiment.reset
+      end
+
+      context "when the experiment no longer exists" do
+        it "doesn't include the experiment" do
+          expect(@subject.active_experiments).to be_empty
+        end
+      end
+
+      context "when the experiment exists" do
+        before do
+          allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        end
+
+        it "only includes the experiment when there is no winner" do
+          allow(experiment).to receive(:has_winner?).and_return(false)
+
+          expect(@subject.active_experiments).to eq({'link_color' => 'blue'})
+        end
+
+        it "doesn't include the experiment when there is a winner" do
+          allow(experiment).to receive(:has_winner?).and_return(true)
+
+          expect(@subject.active_experiments).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
fixes https://github.com/clio/themis/issues/88898
### What problem does this solve?
We have our own keys other than `finished` saved in Redis, like `eligibility` or `time_of_assignment`. Split only treats the `exp`, `exp:2`, or `exp:finished` as the experiment context. To avoid these keys influencing Split's behaviour, and to avoid building up the list of the experiment context, we should find all the experiment contexts by the pattern. Otherwise, the function like `keys_without_experiment` won't be about to filter out `eligibility` or `time_of_assignment` for an experiment. 

### How does this solve it?
Update the calculation of `keys_without_experiment` and `experiment_keys`

Note: this is a squashed PR. Original PR: https://github.com/clio/split/pull/29