### PR TITLE
add new algorithm for systematic sampling

### DIFF
--- a/lib/split.rb
+++ b/lib/split.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'redis'
 
+require 'split/algorithms/systematic_sampling'
 require 'split/algorithms/block_randomization'
 require 'split/algorithms/weighted_sample'
 require 'split/algorithms/whiplash'

--- a/lib/split/algorithms/systematic_sampling.rb
+++ b/lib/split/algorithms/systematic_sampling.rb
@@ -3,14 +3,20 @@ module Split
   module Algorithms
     module SystematicSampling
       def self.choose_alternative(experiment)
-        count = experiment.next_cohorting_block_index
+        count = experiment.next_cohorting_block_count
 
         block_length = experiment.cohorting_block_magnitude * experiment.alternatives.length
         block_num, index = count.divmod block_length
 
+        block = generate_block(block_num, experiment)
+        block[index]
+      end
+
+      private
+       
+      def self.generate_block(block_num, experiment)
         r = Random.new(block_num + experiment.cohorting_block_seed)
         block = (experiment.alternatives*experiment.cohorting_block_magnitude).shuffle(random: r)
-        block[index]
       end
     end
   end

--- a/lib/split/algorithms/systematic_sampling.rb
+++ b/lib/split/algorithms/systematic_sampling.rb
@@ -3,15 +3,14 @@ module Split
   module Algorithms
     module SystematicSampling
       def self.choose_alternative(experiment)
-        block = experiment.cohorting_block
-        raise ArgumentError, "Experiment configuration is missing cohorting_block array" unless block
-        index = experiment.participant_count % block.length
-        chosen_alternative = block[index]
-        alt = experiment.alternatives.find do |alt|
-          alt.name == chosen_alternative
-        end
-        raise ArgumentError, "Invalid cohorting_block: '#{chosen_alternative}' is not an experiment alternative" unless alt
-        alt
+        count = experiment.next_cohorting_block_index
+
+        block_length = experiment.cohorting_block_magnitude * experiment.alternatives.length
+        block_num, index = count.divmod block_length
+
+        r = Random.new(block_num + experiment.cohorting_block_seed)
+        block = (experiment.alternatives*experiment.cohorting_block_magnitude).shuffle(random: r)
+        block[index]
       end
     end
   end

--- a/lib/split/algorithms/systematic_sampling.rb
+++ b/lib/split/algorithms/systematic_sampling.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Split
+  module Algorithms
+    module SystematicSampling
+      def self.choose_alternative(experiment)
+        block = experiment.cohorting_block
+        raise ArgumentError, "Experiment configuration is missing cohorting_block array" unless block
+        index = experiment.participant_count % block.length
+        chosen_alternative = block[index]
+        alt = experiment.alternatives.find do |alt|
+          alt.name == chosen_alternative
+        end
+        raise ArgumentError, "Invalid cohorting_block: '#{chosen_alternative}' is not an experiment alternative" unless alt
+        alt
+      end
+    end
+  end
+end

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -165,7 +165,8 @@ module Split
           resettable: value_for(settings, :resettable),
           friendly_name: value_for(settings, :friendly_name),
           retain_user_alternatives_after_reset:  value_for(settings, :retain_user_alternatives_after_reset),
-          cohorting_block: value_for(settings, :cohorting_block)
+          cohorting_block_seed: value_for(settings, :cohorting_block_seed),
+          cohorting_block_magnitude: value_for(settings, :cohorting_block_magnitude)
         }
 
         experiment_data.each do |name, value|

--- a/lib/split/configuration.rb
+++ b/lib/split/configuration.rb
@@ -164,7 +164,8 @@ module Split
           algorithm: value_for(settings, :algorithm),
           resettable: value_for(settings, :resettable),
           friendly_name: value_for(settings, :friendly_name),
-          retain_user_alternatives_after_reset:  value_for(settings, :retain_user_alternatives_after_reset)
+          retain_user_alternatives_after_reset:  value_for(settings, :retain_user_alternatives_after_reset),
+          cohorting_block: value_for(settings, :cohorting_block)
         }
 
         experiment_data.each do |name, value|

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -444,7 +444,7 @@ module Split
     end
 
     def next_cohorting_block_count
-      Split.redis.incr("#{name}:cohorting_block_count") - 1
+      Split.redis.incr("#{key}:cohorting_block_count") - 1
     end
 
     protected

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -48,7 +48,7 @@ module Split
       self.retain_user_alternatives_after_reset = options_with_defaults[:retain_user_alternatives_after_reset]
 
       if self.algorithm == Split::Algorithms::SystematicSampling
-        self.cohorting_block_seed = options_with_defaults[:cohorting_block_seed] || self.name.to_i(36)
+        self.cohorting_block_seed = options_with_defaults[:cohorting_block_seed] || self.name.sum
         self.cohorting_block_magnitude = options_with_defaults[:cohorting_block_magnitude]
       end
     end
@@ -443,8 +443,8 @@ module Split
       redis.hset(experiment_config_key, :cohorting, false)
     end
 
-    def next_cohorting_block_index
-      Split.redis.incr("#{name}:cohorting_block_index") - 1
+    def next_cohorting_block_count
+      Split.redis.incr("#{name}:cohorting_block_count") - 1
     end
 
     protected

--- a/spec/algorithms/systematic_sampling_spec.rb
+++ b/spec/algorithms/systematic_sampling_spec.rb
@@ -22,7 +22,6 @@ describe Split::Algorithms::SystematicSampling do
         results[Split::Algorithms::SystematicSampling.choose_alternative(experiment).name] += 1
       end
 
-      expect(experiment.cohorting_block_magnitude * experiment.alternatives.length).to eq(6)
       expect(results).to eq({'red' => 2, 'blue' => 2, 'green' => 2})
     end
 
@@ -36,7 +35,6 @@ describe Split::Algorithms::SystematicSampling do
         results[Split::Algorithms::SystematicSampling.choose_alternative(experiment).name] += 1
       end
 
-      expect(experiment.cohorting_block_magnitude * experiment.alternatives.length).to eq(6)
       expect(results).to eq({'red' => 2, 'blue' => 2, 'green' => 2})
     end
   end
@@ -52,7 +50,8 @@ describe Split::Algorithms::SystematicSampling do
     end
 
     let(:seeded_experiment2) do
-      Split::Experiment.new('link_highlight',
+      Split::Experiment.new(
+        'link_highlight',
         :alternatives => ['red', 'blue', 'green'],
         :algorithm => Split::Algorithms::SystematicSampling,
         :cohorting_block_seed => 1234)

--- a/spec/algorithms/systematic_sampling_spec.rb
+++ b/spec/algorithms/systematic_sampling_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Split::Algorithms::SystematicSampling do
+  # it "should return an alternative" do
+  #   experiment = Split::ExperimentCatalog.find_or_create('link_color', {'blue' => 100}, {'red' => 0 })
+  #   expect(Split::Algorithms::WeightedSample.choose_alternative(experiment).class).to eq(Split::Alternative)
+  # end
+
+  # it "should always return a heavily weighted option" do
+  #   experiment = Split::ExperimentCatalog.find_or_create('link_color', {'blue' => 100}, {'red' => 0 })
+  #   expect(Split::Algorithms::WeightedSample.choose_alternative(experiment).name).to eq('blue')
+  # end
+
+  context "for a valid experiment" do
+    let!(:valid_experiment) do
+      Split::Experiment.new('link_color', :alternatives => ['red', 'blue', 'green'], :cohorting_block => ['red', 'blue', 'green'])
+    end
+  
+    let(:red_alternative) { Split::Alternative.new('red', 'link_color') }
+
+    it "cohorts the first user into the first alternative defined in cohorting_block" do
+      expect(Split::Algorithms::SystematicSampling.choose_alternative(valid_experiment).name).to equal "red"
+    end
+
+    it "cohorts the second user into the second alternative defined in cohorting_block" do
+      red_alternative.increment_participation
+
+      expect(Split::Algorithms::SystematicSampling.choose_alternative(valid_experiment).name).to equal "blue"
+    end
+
+    it "cohorts the fourth user into the first alternative defined in cohorting_block" do
+      red_alternative.increment_participation
+      red_alternative.increment_participation
+      red_alternative.increment_participation
+
+      expect(Split::Algorithms::SystematicSampling.choose_alternative(valid_experiment).name).to equal "red"
+    end
+  end
+
+  context "for an experiment with no cohorting_block defined" do
+    let!(:missing_config_experiment) do
+      Split::Experiment.new('link_color', :alternatives => ['red', 'blue', 'green'])
+    end
+
+    it "Throws argument error with descriptive message" do
+      expect { Split::Algorithms::SystematicSampling.choose_alternative(missing_config_experiment).name }
+        .to raise_error(ArgumentError, "Experiment configuration is missing cohorting_block array")
+    end
+  end
+
+  context "for an experiment with invalid cohorting_block defined" do 
+    let!(:invalid_config_experiment) do
+      Split::Experiment.new('link_color', :alternatives => ['red', 'blue', 'green'], :cohorting_block => ['notarealalternative', 'blue', 'green'])
+    end
+
+    it "Throws argument error with descriptive message" do
+      expect { Split::Algorithms::SystematicSampling.choose_alternative(invalid_config_experiment).name }
+        .to raise_error(ArgumentError, "Invalid cohorting_block: 'notarealalternative' is not an experiment alternative")
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -135,6 +135,9 @@ describe Split::Configuration do
                   percent: 23
               resettable: false
               retain_user_alternatives_after_reset: true
+              algorithm: Split::Algorithms::SystematicSampling
+              cohorting_block_seed: 999
+              cohorting_block_magnitude: 3
               metric: my_metric
             another_experiment:
               alternatives:
@@ -145,8 +148,9 @@ describe Split::Configuration do
         end
 
         it "should normalize experiments" do
-          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:retain_user_alternatives_after_reset=>true,:alternatives=>[{"Control Opt"=>0.67},
-            [{"Alt One"=>0.1}, {"Alt Two"=>0.23}]]}, :another_experiment=>{:alternatives=>["a", ["b"]]}})
+          expect(@config.normalized_experiments).to eq({:my_experiment=>{:resettable=>false,:retain_user_alternatives_after_reset=>true, :cohorting_block_magnitude=>3,
+            :algorithm=>"Split::Algorithms::SystematicSampling", :cohorting_block_seed=>999,:alternatives=>[{"Control Opt"=>0.67},[{"Alt One"=>0.1}, {"Alt Two"=>0.23}]]},
+            :another_experiment=>{:alternatives=>["a", ["b"]]}})
         end
 
         it "should recognize metrics" do

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -167,10 +167,10 @@ describe Split::Experiment do
 
       it 'when the experiment is using SystematicSampling algorithm, assigns cohorting_block_seed to a default value' do
         expect(Split::Experiment.new('systematic_sampling_exp', algorithm: Split::Algorithms::SystematicSampling).cohorting_block_seed)
-          .to eq(387211932128858527590062598078109)
+          .to eq(2476)
 
         expect(Split::Experiment.new('systematic_sampling_exp2', algorithm: Split::Algorithms::SystematicSampling).cohorting_block_seed)
-          .to eq(13939629556638906993242253530811926)
+          .to eq(2526)
       end
 
       it "sets friendly_name" do
@@ -467,20 +467,20 @@ describe Split::Experiment do
     end
   end
 
-  describe '#next_cohorting_block_index' do
+  describe '#next_cohorting_block_count' do
     it 'increments each call and starts at 0' do
-      expect(experiment.next_cohorting_block_index).to eq(0)
-      expect(experiment.next_cohorting_block_index).to eq(1)
-      expect(experiment.next_cohorting_block_index).to eq(2)
-      expect(experiment.next_cohorting_block_index).to eq(3)
+      expect(experiment.next_cohorting_block_count).to eq(0)
+      expect(experiment.next_cohorting_block_count).to eq(1)
+      expect(experiment.next_cohorting_block_count).to eq(2)
+      expect(experiment.next_cohorting_block_count).to eq(3)
     end
 
     it 'persists value' do
-      expect(experiment.next_cohorting_block_index).to eq(0)
+      expect(experiment.next_cohorting_block_count).to eq(0)
       experiment.save
 
       e = Split::ExperimentCatalog.find("link_color")
-      expect(e.next_cohorting_block_index).to eq(1)
+      expect(e.next_cohorting_block_count).to eq(1)
     end
   end
 

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -128,6 +128,11 @@ describe Split::Experiment do
       expect(experiment.retain_user_alternatives_after_reset).to be_truthy
     end
 
+    it "should be possible to make an experiment with a cohorting_block" do
+      experiment = Split::Experiment.new("basket_text", :alternatives => ["Basket", "Cart"], :cohorting_block => ["Basket", "Cart"])
+      expect(experiment.cohorting_block).to eq(["Basket", "Cart"])
+    end
+
     it "sets friendly_name" do
       experiment = Split::Experiment.new('basket_text', :alternatives => ['Basket', "Cart"], :friendly_name => "foo")
       expect(experiment.friendly_name).to eq("foo")
@@ -149,6 +154,7 @@ describe Split::Experiment do
       it 'assigns default values to the experiment' do
         expect(Split::Experiment.new(experiment_name).resettable).to eq(true)
         expect(Split::Experiment.new(experiment_name).retain_user_alternatives_after_reset).to eq(false)
+        expect(Split::Experiment.new(experiment_name).cohorting_block).to match_array ['control', 'alternative']
       end
 
       it "sets friendly_name" do
@@ -183,6 +189,15 @@ describe Split::Experiment do
       e = Split::ExperimentCatalog.find("basket_text")
       expect(e).to eq(experiment)
       expect(e.retain_user_alternatives_after_reset).to be_truthy
+    end
+
+    it "should persist cohorting_block" do
+      experiment = Split::Experiment.new("basket_text", :alternatives => ['Basket', "Cart"], :cohorting_block => ["Basket", "Cart"])
+      experiment.save
+
+      e = Split::ExperimentCatalog.find("basket_text")
+      expect(e).to eq(experiment)
+      expect(e.cohorting_block).to match_array ["Basket", "Cart"]
     end
 
     describe '#metadata' do


### PR DESCRIPTION
Kyle has requested a new algorithm that can reduce the difference in participant counts between each alternative. 

From the original ticket: (https://github.com/clio/themis/issues/88629)
> The current randomization mechanism during cohorting is a simple coin flip...

> There is one major downside to doing it this way:

> - We end up with skewed group sizes. If we need 500 samples each in control or alternative, we often end up with 550 in one group and 500 in the other by the time the experiment completes.
> - That leads to higher variance in many of the experiment metrics, and makes the data harder to analyze overall.

> Kyle’s suggestion is to use “segments” rather than coin flips. In our implementation, the Split framework could store a “segment” array in Redis for each experiment. If the segment size was 10, then the array might be:
> [0, 1, 1, 1, 0, 0, 1, 0, 0, 1]

See more information about the feature request here: https://github.com/clio/themis/issues/88629

### Test Plan
- [x] Download Robin's [Split testing tool](https://github.com/robin-phung/split-rails-test)
- [x] Download and checkout this branch of the split gem
- [x] Set split-rails-test gemfile to point to the downloaded path of your local split gem (ex: `gem 'split', path: "../../clio/split", require: 'split/dashboard'`)
- [x] Go to the `experiments.yml` and add the following experiments:
```YAML
exp999:
  alternatives:
    - control
    - alternativeone
    - alternativetwo
  resettable: true
  algorithm: Split::Algorithms::SystematicSampling
  cohorting_block_seed: 1234
  cohorting_block_magnitude: 2
exp888:
  alternatives:
    - control
    - alternative
  resettable: true
  algorithm: Split::Algorithms::SystematicSampling
```
- [x] Run `bundle install`
- [x] Run `rails s`
- [x] Go to http://localhost:3000/split
- [x] Add `exp999` to the board from the dropdown and start it
- [x] Navigate to the following urls to cohort users:
  - `http://localhost:3000/test/index?user=1&test=true&experiment=exp999`
  -  Cohorts user 1 into 'alternativetwo
  - `http://localhost:3000/test/index?user=2&test=true&experiment=exp999`
  -  Cohorts user 2 into 'alternativeone'
  - `http://localhost:3000/test/index?user=3&test=true&experiment=exp999`
  - [x] Cohorts user 3 into 'alternativetwo'
  - `http://localhost:3000/test/index?user=4&test=true&experiment=exp999`
  - [x] Cohorts user 4 into 'control'
  - `http://localhost:3000/test/index?user=5&test=true&experiment=exp999`
  - [x] Cohorts user 5 into 'alternativeone'
  - `http://localhost:3000/test/index?user=5&test=true&experiment=exp999`
  - [x] Cohorts user 6 into 'control'
- [x] Add `exp888` to the board from the dropdown and start it
- [x] Cohort 2 users with the following urls:
  - `http://localhost:3000/test/index?user=10&test=true&experiment=exp888`
  - `http://localhost:3000/test/index?user=11&test=true&experiment=exp888` 
- [x] Refresh `http://localhost:3000/split/` and verify that there is one user in 'control' and one user in 'alternative'
- [x] Again, cohort 2 users with the following urls:
  - `http://localhost:3000/test/index?user=12&test=true&experiment=exp888`
  - `http://localhost:3000/test/index?user=13&test=true&experiment=exp888` 
- [x] Refresh `http://localhost:3000/split/` and verify that there are two users in 'control' and two in 'alternative'
- [x] Cohort one more user in exp888: `http://localhost:3000/test/index?user=14&test=true&experiment=exp888`
- [x] Press "delete experiment data' on the split dashboard for `exp888`
- [x] Again, cohort 2 users with the following urls:
  - `http://localhost:3000/test/index?user=100&test=true&experiment=exp888`
  - `http://localhost:3000/test/index?user=200&test=true&experiment=exp888` 
- [x] Refresh `http://localhost:3000/split/` and verify that there is now one user in 'control' and one in 'alternative'

### Tips
If ruby is 3.0.1 is not installed, run: 
```
brew update && brew upgrade ruby-build
rbenv install 3.0.1
```

If redis is not installed, run:
```
brew install redis
brew tap homebrew/services
brew services start redis
```