### PR TITLE
Update Redis keys cleanup

### DIFF
--- a/lib/split/trial.rb
+++ b/lib/split/trial.rb
@@ -46,7 +46,7 @@ module Split
           end
         end
 
-        delete_time_of_assignment_key
+        delete_experiment_context_keys
         run_callback context, Split.configuration.on_trial_complete
       end
     end
@@ -125,8 +125,11 @@ module Split
       @user_experiment_key ||= @user.alternative_key_for_experiment(@experiment)
     end
 
-    def delete_time_of_assignment_key
-      @user.delete("#{user_experiment_key}:time_of_assignment")
+    def delete_experiment_context_keys
+      keys = @user.all_fields_for_experiment_key(user_experiment_key)
+      keys.each do |key|
+        @user.delete(key) unless key == user_experiment_key || key == Experiment.finished_key(user_experiment_key)
+      end
     end
 
     def save_time_that_user_is_assigned

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -14,9 +14,22 @@ module Split
 
     def cleanup_old_experiments!
       return if @cleaned_up
+      exp_to_delete = {}
+
       user.keys.each do |key|
-        experiment = ExperimentCatalog.find experiment_name(key)
-        if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
+        exp_name = experiment_name(key)
+
+        unless exp_to_delete.include?(exp_name)
+          experiment = ExperimentCatalog.find exp_name
+
+          if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
+            exp_to_delete[exp_name] = true
+          else
+            exp_to_delete[exp_name] = false
+          end
+        end
+
+        if exp_to_delete[exp_name]
           user.delete key
         end
       end

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -14,12 +14,10 @@ module Split
 
     def cleanup_old_experiments!
       return if @cleaned_up
-      experiment_keys(user.keys).each do |key|
-        experiment = ExperimentCatalog.find key_without_version(key)
+      user.keys.each do |key|
+        experiment = ExperimentCatalog.find experiment_name(key)
         if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
           user.delete key
-          user.delete Experiment.finished_key(key)
-          user.delete "#{key}:time_of_assignment"
         end
       end
       @cleaned_up = true
@@ -55,32 +53,39 @@ module Split
     end
 
     def alternative_key_for_experiment(experiment)
-      if experiment.version > 0
-        keys = user.keys
+      user_experiment_key = first_field_from_all_versions(experiment)
+      #default to current experiment key when one isn't found
+      user_experiment_key || experiment.key
+    end
 
-        #default to current experiment key when one isn't found
-        user_experiment_key = experiment.key
+    def all_fields_for_experiment_key(experiment_key)
+      user.keys - keys_without_experiment(user.keys, experiment_key)
+    end
 
-        #first version is not colon delimited 
-        if keys.include?(experiment.name)
-          user_experiment_key = experiment.name
-        else
-          experiment.version.times do |version_number|
-            key = "#{experiment.name}:#{version_number+1}"
-            if keys.include?(key)
-              user_experiment_key = key
-              break
-            end
+    def first_field_from_all_versions(experiment, exp_attribute = "")
+      keys = user.keys
+      exp_attribute = ":#{exp_attribute}" unless exp_attribute.empty?
+      result = nil
+
+      if keys.include?(experiment.name + exp_attribute)
+        result = experiment.name + exp_attribute
+      else
+        experiment.version.times do |version_number|
+          key = "#{experiment.name}:#{version_number+1}" + exp_attribute
+          if keys.include?(key)
+            result = key
+            break
           end
         end
-
-        user_experiment_key
-      else
-        experiment.key
       end
+
+      result
     end
 
     private
+    def experiment_name(key)
+      key.partition(':').first
+    end
 
     def keys_without_experiment(keys, experiment_key)
       if experiment_key.include?(':')

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -21,12 +21,7 @@ module Split
 
         unless exp_to_delete.include?(exp_name)
           experiment = ExperimentCatalog.find exp_name
-
-          if experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
-            exp_to_delete[exp_name] = true
-          else
-            exp_to_delete[exp_name] = false
-          end
+          exp_to_delete[exp_name] = experiment.nil? || experiment.has_winner? || experiment.start_time.nil?
         end
 
         if exp_to_delete[exp_name]

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -352,7 +352,7 @@ describe Split::Trial do
     end
 
     it "removes the context keys for that experiment" do
-      user[experiment.key + ":eligibility"] = "ELIGIBLE"
+      user[experiment.key + ":external_key"] = "value"
       trial.complete!
       expect(user.keys).to eq [experiment.key]
     end

--- a/spec/trial_spec.rb
+++ b/spec/trial_spec.rb
@@ -351,9 +351,10 @@ describe Split::Trial do
       trial.choose!
     end
 
-    it "removes the time_of_assignment key for that experiment" do
+    it "removes the context keys for that experiment" do
+      user[experiment.key + ":eligibility"] = "ELIGIBLE"
       trial.complete!
-      expect(user[experiment.key + ":time_of_assignment"]).to be nil
+      expect(user.keys).to eq [experiment.key]
     end
 
     it "does not not convert when the user is not within the conversion time frame and experiment key is not the same as the user key" do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -126,51 +126,53 @@ describe Split::User do
   end 
 
   context '#cleanup_old_experiments!' do
-    let(:user_keys) do
-      {
-        'link_color' => 'blue',
-        'link_color:finished' => true,
-        'link_color:time_of_assignment' => Time.now.to_s,
-        'link_color:eligibility' => "ELIGIBLE",
-      }
-    end
+    describe "when the user is in the experiment without version number" do
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color:external_key' => "value",
+        }
+      end
 
-    it 'removes keys if experiment is not found' do
-      @subject.cleanup_old_experiments!
+      it 'removes keys if experiment is not found' do
+        @subject.cleanup_old_experiments!
 
-      expect(@subject.keys).to be_empty
-    end
+        expect(@subject.keys).to be_empty
+      end
 
-    it 'removes keys if experiment has a winner' do
-      allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-      allow(experiment).to receive(:has_winner?).and_return(true)
-      allow(experiment).to receive(:start_time).and_return(Date.today)
-      
-      @subject.cleanup_old_experiments!
-      
-      expect(@subject.keys).to be_empty
-    end
+      it 'removes keys if experiment has a winner' do
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        allow(experiment).to receive(:has_winner?).and_return(true)
+        allow(experiment).to receive(:start_time).and_return(Date.today)
 
-    it 'removes keys if experiment has not started yet' do
-      allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-      allow(experiment).to receive(:has_winner?).and_return(false)
-      allow(experiment).to receive(:start_time).and_return(nil)
-      
-      @subject.cleanup_old_experiments!
-      
-      expect(@subject.keys).to be_empty
-    end
+        @subject.cleanup_old_experiments!
 
-    it 'keeps keys if the experiment has no winner and has started' do
-      allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
-      allow(experiment).to receive(:has_winner?).and_return(false)
-      allow(experiment).to receive(:start_time).and_return(Date.today)
-      
-      @subject.cleanup_old_experiments!
-      
-      expect(@subject.keys).to include("link_color")
-      expect(@subject.keys).to include("link_color:finished")
-      expect(@subject.keys).to include("link_color:time_of_assignment")
+        expect(@subject.keys).to be_empty
+      end
+
+      it 'removes keys if experiment has not started yet' do
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        allow(experiment).to receive(:has_winner?).and_return(false)
+        allow(experiment).to receive(:start_time).and_return(nil)
+
+        @subject.cleanup_old_experiments!
+
+        expect(@subject.keys).to be_empty
+      end
+
+      it 'keeps keys if the experiment has no winner and has started' do
+        allow(Split::ExperimentCatalog).to receive(:find).with('link_color').and_return(experiment)
+        allow(experiment).to receive(:has_winner?).and_return(false)
+        allow(experiment).to receive(:start_time).and_return(Date.today)
+
+        @subject.cleanup_old_experiments!
+
+        expect(@subject.keys).to include("link_color")
+        expect(@subject.keys).to include("link_color:finished")
+        expect(@subject.keys).to include("link_color:time_of_assignment")
+      end
     end
 
     describe "when the user is in the experiment with version number" do
@@ -180,6 +182,12 @@ describe Split::User do
           'link_color:1:finished' => true,
           'link_color:1:time_of_assignment' => Time.now.to_s,
         }
+      end
+
+      it 'removes keys if the experiment is not found' do
+        @subject.cleanup_old_experiments!
+
+        expect(@subject.keys).to be_empty
       end
 
       it 'keeps keys when the experiment has no winner and has started' do
@@ -192,6 +200,32 @@ describe Split::User do
         expect(@subject.keys).to include("link_color:1")
         expect(@subject.keys).to include("link_color:1:finished")
         expect(@subject.keys).to include("link_color:1:time_of_assignment")
+      end
+    end
+
+    describe "when the user is in two experiments with similar names" do
+      let(:user_keys) do
+        {
+          'link_color' => 'blue',
+          'link_color:finished' => true,
+          'link_color:time_of_assignment' => Time.now.to_s,
+          'link_color_v2' => 'blue',
+          'link_color_v2:finished' => true,
+          'link_color_v2:time_of_assignment' => Time.now.to_s,
+        }
+      end
+
+      it 'only delete the keys for non-existent experiment' do
+        experiment = Split::Experiment.new('link_color_v2')
+        alternatives = %w[control blue]
+        Split::ExperimentCatalog.find_or_create("link_color_v2", alternatives)
+        experiment.start
+
+        @subject.cleanup_old_experiments!
+
+        expect(@subject.keys).to include("link_color_v2")
+        expect(@subject.keys).to include("link_color_v2:finished")
+        expect(@subject.keys).to include("link_color_v2:time_of_assignment")
       end
     end
 
@@ -227,7 +261,7 @@ describe Split::User do
             'link_color' => 'blue',
             'link_color:finished' => true,
             'link_color:time_of_assignment' => Time.now.to_s,
-            'link_color:eligibility' => "ELIGIBLE",
+            'link_color:external_key' => "value",
           }
         end
 
@@ -246,7 +280,7 @@ describe Split::User do
             'link_color:1' => 'blue',
             'link_color:1:finished' => true,
             'link_color:1:time_of_assignment' => Time.now.to_s,
-            'link_color:1:eligibility' => "ELIGIBLE",
+            'link_color:1:external_key' => "value",
           }
         end
 
@@ -296,7 +330,7 @@ describe Split::User do
             'link_shape' => 'control',
             'link_shape:finished' => true,
             'link_shape:time_of_assignment' => Time.now.to_s,
-            'link_shape:eligibility' => "ELIGIBLE",
+            'link_shape:external_key' => "value",
           }
         end
 
@@ -311,11 +345,11 @@ describe Split::User do
             'link_color' => 'blue',
             'link_color:finished' => true,
             'link_color:time_of_assignment' => Time.now.to_s,
-            'link_color:eligibility' => "ELIGIBLE",
+            'link_color:external_key' => "value",
             'link_shape' => 'control',
             'link_shape:finished' => true,
             'link_shape:time_of_assignment' => Time.now.to_s,
-            'link_shape:eligibility' => "ELIGIBLE",
+            'link_shape:external_key' => "value",
           }
         end
 
@@ -333,11 +367,11 @@ describe Split::User do
           'link_color' => 'blue',
           'link_color:finished' => true,
           'link_color:time_of_assignment' => Time.now.to_s,
-          'link_color:eligibility' => "ELIGIBLE",
+          'link_color:external_key' => "value",
           'link_shape' => 'blue',
           'link_shape:finished' => true,
           'link_shape:time_of_assignment' => Time.now.to_s,
-          'link_shape:eligibility' => "ELIGIBLE",
+          'link_shape:external_key' => "value",
         }
       end
 
@@ -360,7 +394,7 @@ describe Split::User do
           'link_color' => 'blue',
           'link_color:finished' => true,
           'link_color:time_of_assignment' => Time.now.to_s,
-          'link_color:eligibility' => "ELIGIBLE",
+          'link_color:external_key' => "value",
         }
       end
 
@@ -395,7 +429,7 @@ describe Split::User do
           'link_color:1' => 'blue',
           'link_color:1:finished' => true,
           'link_color:1:time_of_assignment' => Time.now.to_s,
-          'link_color:1:eligibility' => "ELIGIBLE",
+          'link_color:1:external_key' => "value",
         }
       end
       before do
@@ -479,7 +513,7 @@ describe Split::User do
           'link_color' => 'blue',
           'link_color:finished' => true,
           'link_color:time_of_assignment' => Time.now.to_s,
-          'link_color:eligibility' => "ELIGIBLE",
+          'link_color:external_key' => "value",
           'link_color_v2' => 'blue',
           'link_color:1' => 'blue',
           'lk_cl' => 'blue',
@@ -488,7 +522,7 @@ describe Split::User do
 
       it "returns only the experiment fields" do
         expect(@subject.all_fields_for_experiment_key(experiment.key)).to eq(
-                        %w[link_color link_color:finished link_color:time_of_assignment link_color:eligibility])
+                        %w[link_color link_color:finished link_color:time_of_assignment link_color:external_key])
       end
     end
 
@@ -498,7 +532,7 @@ describe Split::User do
           'link_color:1' => 'blue',
           'link_color:1:finished' => true,
           'link_color:1:time_of_assignment' => Time.now.to_s,
-          'link_color:1:eligibility' => "ELIGIBLE",
+          'link_color:1:external_key' => "value",
           'link_color_v2:1' => 'blue',
           'link_color' => 'blue',
           'link_color:2' => 'blue',
@@ -508,7 +542,7 @@ describe Split::User do
 
       it "returns only the versioned fields" do
         expect(@subject.all_fields_for_experiment_key("link_color:1")).to eq(
-                  %w[link_color:1 link_color:1:finished link_color:1:time_of_assignment link_color:1:eligibility])
+                  %w[link_color:1 link_color:1:finished link_color:1:time_of_assignment link_color:1:external_key])
       end
     end
   end
@@ -518,7 +552,7 @@ describe Split::User do
       let(:user_keys) do
         {
           'link_color' => 'blue',
-          'link_color:eligibility' => "ELIGIBLE",
+          'link_color:external_key' => "value",
           'link_color_v2' => 'blue',
           'link_color:1' => 'blue',
           'lk_cl' => 'blue',
@@ -530,19 +564,19 @@ describe Split::User do
       end
 
       it "returns experiment field" do
-        expect(@subject.first_field_from_all_versions(experiment, "eligibility")).to eq('link_color:eligibility')
+        expect(@subject.first_field_from_all_versions(experiment, "external_key")).to eq('link_color:external_key')
       end
 
-      it "returns nil for non-exist field" do
+      it "returns nil for non-existent field" do
         expect(@subject.first_field_from_all_versions(experiment, "random_field")).to be_nil
       end
     end
 
-    describe "when  experiment field has version" do
+    describe "when experiment field has version" do
       let(:user_keys) do
         {
           'link_color:2' => 'blue',
-          'link_color:2:eligibility' => "ELIGIBLE",
+          'link_color:2:external_key' => "value",
           'link_color_v2:1' => 'blue',
           'lk_cl:1' => 'blue',
         }
@@ -556,10 +590,10 @@ describe Split::User do
       end
 
       it "returns versioned experiment field" do
-        expect(@subject.first_field_from_all_versions(experiment, "eligibility")).to eq('link_color:2:eligibility')
+        expect(@subject.first_field_from_all_versions(experiment, "external_key")).to eq('link_color:2:external_key')
       end
 
-      it "returns nil for non-exist field" do
+      it "returns nil for non-existent field" do
         expect(@subject.first_field_from_all_versions(experiment, "random_field")).to be_nil
       end
     end


### PR DESCRIPTION
resolve [#86339](https://github.com/clio/themis/issues/86339)
### What problem does this solve?
The current implementation explicitly deletes Redis keys by the key names. This PR will extend the deletion to contain all the keys except the alternative and finished keys.

### How does this solve it?
Delete all the keys except the alternative and finished keys. Added and exposed some public helper methods, so that we can reduce code duplication in the Themis.
